### PR TITLE
Fix waystone item model scaling in GUIs and item frames

### DIFF
--- a/src/main/resources/assets/waystones/models/item/waystone.json
+++ b/src/main/resources/assets/waystones/models/item/waystone.json
@@ -3,8 +3,8 @@
   "display": {
     "gui": {
       "rotation": [ 30, 45, 0 ],
-      "translation": [ 0, 0, 0],
-      "scale":[ 0.625, 0.625, 0.625 ]
+      "translation": [ 0, -2, 0],
+      "scale":[ 0.4, 0.4, 0.4 ]
     },
     "ground": {
       "rotation": [ 0, 0, 0 ],
@@ -18,7 +18,7 @@
     },
     "fixed": {
       "rotation": [ 0, 180, 0 ],
-      "translation": [ 0, 0, 0],
+      "translation": [ 0, -4, 0],
       "scale":[ 0.5, 0.5, 0.5 ]
     },
     "thirdperson_righthand": {


### PR DESCRIPTION
This pull request prevents the item model from extending outside the slot / item frame bounds.

![Screenshot of item model in GUI and item frame](http://i.imgur.com/Mlgx7yY.png)