### PR TITLE
use ore dictionary for all components

### DIFF
--- a/src/main/resources/assets/waystones/recipes/_constants.json
+++ b/src/main/resources/assets/waystones/recipes/_constants.json
@@ -19,5 +19,19 @@
       "type": "forge:ore_dict",
       "ore": "gemEmerald"
     }
+  },
+  {
+    "name": "ENDER_PEARL",
+    "ingredient": {
+      "type": "forge:ore_dict",
+      "ore": "enderpearl"
+    }
+  },
+  {
+    "name": "PAPER",
+    "ingredient": {
+      "type": "forge:ore_dict",
+      "ore": "paper"
+    }
   }
 ]

--- a/src/main/resources/assets/waystones/recipes/return_scroll.json
+++ b/src/main/resources/assets/waystones/recipes/return_scroll.json
@@ -13,10 +13,10 @@
       "item": "#GOLD_NUGGET"
     },
     "E": {
-      "item": "minecraft:ender_pearl"
+      "item": "#ENDER_PEARL"
     },
     "P": {
-      "item": "minecraft:paper"
+      "item": "#PAPER"
     }
   }
 }

--- a/src/main/resources/assets/waystones/recipes/warp_scroll.json
+++ b/src/main/resources/assets/waystones/recipes/warp_scroll.json
@@ -14,10 +14,10 @@
       "item": "#GOLD_NUGGET"
     },
     "E": {
-      "item": "minecraft:ender_pearl"
+      "item": "#ENDER_PEARL"
     },
     "P": {
-      "item": "minecraft:paper"
+      "item": "#PAPER"
     },
     "D": {
       "item": "#PURPLE_DYE"

--- a/src/main/resources/assets/waystones/recipes/warp_stone.json
+++ b/src/main/resources/assets/waystones/recipes/warp_stone.json
@@ -13,7 +13,7 @@
       "item": "#EMERALD"
     },
     "E": {
-      "item": "minecraft:ender_pearl"
+      "item": "#ENDER_PEARL"
     },
     "D": {
       "item": "#PURPLE_DYE"


### PR DESCRIPTION
Update all recipes to use ore dictionary entries instead of specific items. In vanilla 1.12.2 this does nothing. In mods that add items to paper or enderpearl ore dictionaries, those ingredients can be used as well.

I've tested this in minecraft 1.12.2 with forge 14.23.4.2707.

Let me know if you would prefer the PR against master, I assumed if you wanted this change that you'd integrate from this release branch.