### PR TITLE
Fixes issue #153

### DIFF
--- a/src/main/java/net/blay09/mods/waystones/item/ItemBoundScroll.java
+++ b/src/main/java/net/blay09/mods/waystones/item/ItemBoundScroll.java
@@ -105,18 +105,32 @@ public class ItemBoundScroll extends Item implements IResetUseOnDamage {
     }
 
     @Override
-    public ItemStack onItemUseFinish(ItemStack itemStack, World world, EntityLivingBase entity) {
-        if (!world.isRemote && entity instanceof EntityPlayer) {
-            WaystoneEntry boundTo = getBoundTo((EntityPlayer) entity, itemStack);
-            if (boundTo != null) {
+    public ItemStack onItemUseFinish(ItemStack itemStack, World world, EntityLivingBase entity)
+    {
+        if (!world.isRemote && entity instanceof EntityPlayer)
+        {
+            EntityPlayer player = (EntityPlayer) entity;
+
+            WaystoneEntry boundTo = getBoundTo(player, itemStack);
+            if (boundTo != null)
+            {
                 double distance = entity.getDistance(boundTo.getPos().getX(), boundTo.getPos().getY(), boundTo.getPos().getZ());
-                if (distance <= 2.0) {
+                if (distance <= 2)
+                {
                     return itemStack;
                 }
 
-                if (WaystoneManager.teleportToWaystone((EntityPlayer) entity, boundTo)) {
-                    if (!((EntityPlayer) entity).capabilities.isCreativeMode) {
-                        itemStack.shrink(1);
+                TileWaystone tileWaystone = WaystoneManager.getWaystoneInWorld(boundTo);
+                if (tileWaystone != null) //If it's going to fail, it should fail here.  If it fails inside this block, I (Laike Endaril) messed up Blay's mod :P
+                {
+                    if (!player.capabilities.isCreativeMode) itemStack.shrink(1);
+
+                    WaystoneManager.addPlayerWaystone(player, boundTo);
+                    WaystoneManager.sendPlayerWaystones(player);
+
+                    if (!WaystoneManager.teleportToWaystone(player, boundTo))
+                    {
+                        System.err.println("Bound scroll failed in the wrong way!  This should never happen, and you should go find Laike Endaril and tell him that he sucks.");
                     }
                 }
             }

--- a/src/main/java/net/blay09/mods/waystones/item/ItemBoundScroll.java
+++ b/src/main/java/net/blay09/mods/waystones/item/ItemBoundScroll.java
@@ -107,30 +107,23 @@ public class ItemBoundScroll extends Item implements IResetUseOnDamage {
     @Override
     public ItemStack onItemUseFinish(ItemStack itemStack, World world, EntityLivingBase entity)
     {
-        if (!world.isRemote && entity instanceof EntityPlayer)
-        {
+        if (!world.isRemote && entity instanceof EntityPlayer) {
             EntityPlayer player = (EntityPlayer) entity;
 
             WaystoneEntry boundTo = getBoundTo(player, itemStack);
-            if (boundTo != null)
-            {
+            if (boundTo != null) {
                 double distance = entity.getDistance(boundTo.getPos().getX(), boundTo.getPos().getY(), boundTo.getPos().getZ());
-                if (distance <= 2)
-                {
+                if (distance <= 2) {
                     return itemStack;
                 }
 
                 TileWaystone tileWaystone = WaystoneManager.getWaystoneInWorld(boundTo);
-                if (tileWaystone != null) //If it's going to fail, it should fail here.  If it fails inside this block, I (Laike Endaril) messed up Blay's mod :P
-                {
-                    if (!player.capabilities.isCreativeMode) itemStack.shrink(1);
-
+                if (tileWaystone != null) {
                     WaystoneManager.addPlayerWaystone(player, boundTo);
                     WaystoneManager.sendPlayerWaystones(player);
 
-                    if (!WaystoneManager.teleportToWaystone(player, boundTo))
-                    {
-                        System.err.println("Bound scroll failed in the wrong way!  This should never happen, and you should go find Laike Endaril and tell him that he sucks.");
+                    if (WaystoneManager.teleportToWaystone(player, boundTo)) {
+                        if (!player.capabilities.isCreativeMode) itemStack.shrink(1);
                     }
                 }
             }

--- a/src/main/java/net/blay09/mods/waystones/item/ItemBoundScroll.java
+++ b/src/main/java/net/blay09/mods/waystones/item/ItemBoundScroll.java
@@ -105,8 +105,7 @@ public class ItemBoundScroll extends Item implements IResetUseOnDamage {
     }
 
     @Override
-    public ItemStack onItemUseFinish(ItemStack itemStack, World world, EntityLivingBase entity)
-    {
+    public ItemStack onItemUseFinish(ItemStack itemStack, World world, EntityLivingBase entity) {
         if (!world.isRemote && entity instanceof EntityPlayer) {
             EntityPlayer player = (EntityPlayer) entity;
 


### PR DESCRIPTION
This fixes bound scrolls not allowing players to teleport to waystones they have not activated.  The method used is to make the bound scroll activate the waystone immediately before teleporting the player, but AFTER checking that the waystone exists and shrinking the ItemStack.  See source for details.