### PR TITLE
Added option to disable generated Waystone drops (fixes #156)

### DIFF
--- a/src/main/java/net/blay09/mods/waystones/WaystoneConfig.java
+++ b/src/main/java/net/blay09/mods/waystones/WaystoneConfig.java
@@ -99,6 +99,10 @@ public class WaystoneConfig {
         @Config.Comment("Whether generated waystones should not be breakable by players.")
         public boolean disallowBreakingGenerated = false;
 
+        @Config.Name("Drop Item From Generated")
+        @Config.Comment("Whether generated waystones drop their item form when broken by players.")
+        public boolean dropGenerated = true;
+
         @Config.Name("Warp Stone Use Time")
         @Config.Comment("The time it takes to use a warp stone in ticks. This is the charge-up time when holding right-click.")
         @Config.RangeInt(min = 1, max = 127)

--- a/src/main/java/net/blay09/mods/waystones/block/TileWaystone.java
+++ b/src/main/java/net/blay09/mods/waystones/block/TileWaystone.java
@@ -145,6 +145,10 @@ public class TileWaystone extends TileEntity {
         return isGlobal;
     }
 
+    public boolean isDummy() {
+        return isDummy;
+    }
+
     public void setGlobal(boolean isGlobal) {
         this.isGlobal = isGlobal;
         markDirty();


### PR DESCRIPTION
I thought this'd be a pretty simple feature, but it turned out to have some surprises.  Namely that it wasn't possible to get the waystone's true TE when harvestBlock was fired.  If you mined the top half, the passed-in TE contained false information.

I came up with a small workaround.  We essentially update the top half during an early phase of the breaking to give it the correct information.  The code comments explain it in more detail.