### PR TITLE
Allow dimensional warping to actually cost XP.

### DIFF
--- a/src/main/java/net/blay09/mods/waystones/config/WaystoneServerConfig.java
+++ b/src/main/java/net/blay09/mods/waystones/config/WaystoneServerConfig.java
@@ -119,7 +119,7 @@ public class WaystoneServerConfig {
         dimensionalWarpXpCost = builder
                 .comment("The base xp level cost when travelling between dimensions. Ignores block distance.")
                 .translation("config.waystones.dimensionalWarpXpCost")
-                .defineInRange("dimensionalWarpXpCost", 3, 0, 0);
+                .defineInRange("dimensionalWarpXpCost", 3, 0, Float.POSITIVE_INFINITY);
 
         builder.pop().comment("These options define restrictions when managing waystones.").push("restrictions");
 


### PR DESCRIPTION
For some reason this was capped at a maximum of zero despite a default of three. I assume this isn't intentional. :)