### PR TITLE
Create a detailed bounding box for waystones that wraps the model

### DIFF
--- a/src/main/java/net/blay09/mods/waystones/block/WaystoneBlock.java
+++ b/src/main/java/net/blay09/mods/waystones/block/WaystoneBlock.java
@@ -49,21 +49,20 @@ import java.util.Random;
 
 public class WaystoneBlock extends Block {
 
-    public static final VoxelShape LOWER_SHAPE, UPPER_SHAPE;
+    public static final VoxelShape LOWER_SHAPE = VoxelShapes.or(
+      makeCuboidShape(0.0, 0.0, 0.0, 16.0, 3.0, 16.0),
+      makeCuboidShape(1.0, 3.0, 1.0, 15.0, 7.0, 15.0),
+      makeCuboidShape(2.0, 7.0, 2.0, 14.0, 9.0, 14.0),
+      makeCuboidShape(3.0, 9.0, 3.0, 13.0, 16.0, 13.0)
+    ).simplify();
 
-    static {
-        VoxelShape l0 = makeCuboidShape(0.0, 0.0, 0.0, 16.0, 3.0, 16.0);
-        VoxelShape l1 = makeCuboidShape(1.0, 3.0, 1.0, 15.0, 7.0, 15.0);
-        VoxelShape l2 = makeCuboidShape(2.0, 7.0, 2.0, 14.0, 9.0, 14.0);
-        VoxelShape l3 = makeCuboidShape(3.0, 9.0, 3.0, 13.0, 16.0, 13.0);
-        VoxelShape u0 = makeCuboidShape(3.0, 0.0, 3.0, 13.0, 8.0, 13.0);
-        VoxelShape u1 = makeCuboidShape(2.0, 8.0, 2.0, 14.0, 10.0, 14.0);
-        VoxelShape u2 = makeCuboidShape(1.0, 10.0, 1.0, 15.0, 12.0, 15.0);
-        VoxelShape u3 = makeCuboidShape(3.0, 12.0, 3.0, 13.0, 14.0, 13.0);
-        VoxelShape u4 = makeCuboidShape(4.0, 14.0, 4.0, 12.0, 16.0, 12.0);
-        LOWER_SHAPE = VoxelShapes.or(l3, VoxelShapes.or(l2, VoxelShapes.or(l1, l0)));
-        UPPER_SHAPE = VoxelShapes.or(u4, VoxelShapes.or(u3, VoxelShapes.or(u2, VoxelShapes.or(u1, u0))));
-    }
+    public static final VoxelShape UPPER_SHAPE = VoxelShapes.or(
+      makeCuboidShape(3.0, 0.0, 3.0, 13.0, 8.0, 13.0),
+      makeCuboidShape(2.0, 8.0, 2.0, 14.0, 10.0, 14.0),
+      makeCuboidShape(1.0, 10.0, 1.0, 15.0, 12.0, 15.0),
+      makeCuboidShape(3.0, 12.0, 3.0, 13.0, 14.0, 13.0),
+      makeCuboidShape(4.0, 14.0, 4.0, 12.0, 16.0, 12.0)
+    ).simplify();
 
     public static final DirectionProperty FACING = BlockStateProperties.HORIZONTAL_FACING;
     public static final EnumProperty<DoubleBlockHalf> HALF = BlockStateProperties.DOUBLE_BLOCK_HALF;

--- a/src/main/java/net/blay09/mods/waystones/block/WaystoneBlock.java
+++ b/src/main/java/net/blay09/mods/waystones/block/WaystoneBlock.java
@@ -30,6 +30,7 @@ import net.minecraft.util.Hand;
 import net.minecraft.util.SoundEvents;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.BlockRayTraceResult;
+import net.minecraft.util.math.shapes.ISelectionContext;
 import net.minecraft.util.math.shapes.VoxelShape;
 import net.minecraft.util.math.shapes.VoxelShapes;
 import net.minecraft.util.text.StringTextComponent;
@@ -48,10 +49,21 @@ import java.util.Random;
 
 public class WaystoneBlock extends Block {
 
-    /**
-     * We provide a slightly smaller render shape to prevent neighbour blocks from being culled.
-     */
-    private static final VoxelShape RENDER_SHAPE = VoxelShapes.create(1 / 16f, 1 / 16f, 1 / 16f, 15 / 16f, 15 / 16f, 15 / 16f);
+    public static final VoxelShape LOWER_SHAPE, UPPER_SHAPE;
+
+    static {
+        VoxelShape l0 = makeCuboidShape(0.0, 0.0, 0.0, 16.0, 3.0, 16.0);
+        VoxelShape l1 = makeCuboidShape(1.0, 3.0, 1.0, 15.0, 7.0, 15.0);
+        VoxelShape l2 = makeCuboidShape(2.0, 7.0, 2.0, 14.0, 9.0, 14.0);
+        VoxelShape l3 = makeCuboidShape(3.0, 9.0, 3.0, 13.0, 16.0, 13.0);
+        VoxelShape u0 = makeCuboidShape(3.0, 0.0, 3.0, 13.0, 8.0, 13.0);
+        VoxelShape u1 = makeCuboidShape(2.0, 8.0, 2.0, 14.0, 10.0, 14.0);
+        VoxelShape u2 = makeCuboidShape(1.0, 10.0, 1.0, 15.0, 12.0, 15.0);
+        VoxelShape u3 = makeCuboidShape(3.0, 12.0, 3.0, 13.0, 14.0, 13.0);
+        VoxelShape u4 = makeCuboidShape(4.0, 14.0, 4.0, 12.0, 16.0, 12.0);
+        LOWER_SHAPE = VoxelShapes.or(l3, VoxelShapes.or(l2, VoxelShapes.or(l1, l0)));
+        UPPER_SHAPE = VoxelShapes.or(u4, VoxelShapes.or(u3, VoxelShapes.or(u2, VoxelShapes.or(u1, u0))));
+    }
 
     public static final DirectionProperty FACING = BlockStateProperties.HORIZONTAL_FACING;
     public static final EnumProperty<DoubleBlockHalf> HALF = BlockStateProperties.DOUBLE_BLOCK_HALF;
@@ -61,8 +73,8 @@ public class WaystoneBlock extends Block {
     }
 
     @Override
-    public VoxelShape getRenderShape(BlockState p_196247_1_, IBlockReader p_196247_2_, BlockPos p_196247_3_) {
-        return RENDER_SHAPE;
+    public VoxelShape getShape(BlockState state, IBlockReader world, BlockPos pos, ISelectionContext context) {
+        return state.get(HALF) == DoubleBlockHalf.UPPER ? UPPER_SHAPE : LOWER_SHAPE;
     }
 
     @Override


### PR DESCRIPTION
The shape is derived from the model, much like shapes for fences and walls in vanilla, and wraps it closely to allow collision and raytracing that is accurate to the perceived block. I considered joining the block shapes for the outline to help it feel more uniform, however, it felt unintuitive when mining the block, as it only rendered the overlay on the targeted half, and reset the mining progress when mousing between them. Perhaps this is something that could be handled in the future but I considered it to be out of scope for this pull request.

![A screenshot of the upper shape](https://user-images.githubusercontent.com/9869940/86061235-4d9c4300-ba5e-11ea-8d73-e5c4c4ea0707.png
)
![A screenshot of the lower shape](https://user-images.githubusercontent.com/9869940/86061252-5c82f580-ba5e-11ea-8224-8ae9e2a5be42.png)

