### PR TITLE
Make Villages spawn Waystones

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -71,9 +71,6 @@ repositories {
         url "https://minecraft.curseforge.com/api/maven/"
     }
     maven {
-        url "https://www.cursemaven.com"
-    }
-    maven {
         name = "Progwml6 maven"
         url = "https://dvs1.progwml6.com/files/maven/"
     }

--- a/build.gradle
+++ b/build.gradle
@@ -71,6 +71,9 @@ repositories {
         url "https://minecraft.curseforge.com/api/maven/"
     }
     maven {
+        url "https://www.cursemaven.com"
+    }
+    maven {
         name = "Progwml6 maven"
         url = "https://dvs1.progwml6.com/files/maven/"
     }

--- a/src/main/java/net/blay09/mods/waystones/Waystones.java
+++ b/src/main/java/net/blay09/mods/waystones/Waystones.java
@@ -21,7 +21,9 @@ import net.minecraft.tileentity.TileEntityType;
 import net.minecraft.world.gen.feature.Feature;
 import net.minecraft.world.gen.placement.Placement;
 import net.minecraftforge.common.ForgeConfigSpec;
+import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.event.RegistryEvent;
+import net.minecraftforge.eventbus.api.IEventBus;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
 import net.minecraftforge.fml.DeferredWorkQueue;
 import net.minecraftforge.fml.DistExecutor;
@@ -31,6 +33,7 @@ import net.minecraftforge.fml.config.ModConfig;
 import net.minecraftforge.fml.event.lifecycle.FMLClientSetupEvent;
 import net.minecraftforge.fml.event.lifecycle.FMLCommonSetupEvent;
 import net.minecraftforge.fml.event.lifecycle.InterModEnqueueEvent;
+import net.minecraftforge.fml.event.server.FMLServerAboutToStartEvent;
 import net.minecraftforge.fml.loading.FMLPaths;
 
 import java.io.File;
@@ -58,6 +61,9 @@ public class Waystones {
         ModLoadingContext.get().registerConfig(ModConfig.Type.COMMON, WaystonesConfig.commonSpec);
         ModLoadingContext.get().registerConfig(ModConfig.Type.CLIENT, WaystonesConfig.clientSpec);
         registerSaneServerConfig(WaystonesConfig.serverSpec, MOD_ID);
+
+        IEventBus forgeBus = MinecraftForge.EVENT_BUS;
+        forgeBus.addListener(Waystones::setupWaystoneVillages);
     }
 
     /**
@@ -89,9 +95,16 @@ public class Waystones {
     public static void setup(FMLCommonSetupEvent event) {
         event.enqueueWork(() -> {
             ModWorldGen.registerConfiguredFeatures();
-            ModWorldGen.setupVillageWorldGen();
         });
     }
+
+    /*
+      Add to Village pools in FMLServerAboutToStartEvent so Waystones shows up in Villages modified by datapacks.
+     */
+    public static void setupWaystoneVillages(FMLServerAboutToStartEvent event) {
+        ModWorldGen.setupVillageWorldGen(event.getServer().func_244267_aX());
+    }
+
 
     @SubscribeEvent
     public static void setupClient(FMLClientSetupEvent event) {

--- a/src/main/java/net/blay09/mods/waystones/config/WaystoneCommonConfig.java
+++ b/src/main/java/net/blay09/mods/waystones/config/WaystoneCommonConfig.java
@@ -23,9 +23,9 @@ public class WaystoneCommonConfig {
         builder.push("worldgen");
 
         addVillageStructure = builder
-                .comment("NOT YET IMPLEMENTED: Set to true if waystones should be added to the generation of villages. THIS OPTION DOES NOT WORK YET.")
+                .comment("Set to true if waystones should be added to the generation of villages.")
                 .translation("config.waystones.addVillageStructure")
-                .define("addVillageStructure", false);
+                .define("addVillageStructure", true);
 
         allowWaystoneToWaystoneTeleport = builder
                 .comment("Set to true if players should be able to teleport between waystones by simply right-clicking a waystone.")

--- a/src/main/java/net/blay09/mods/waystones/worldgen/ModWorldGen.java
+++ b/src/main/java/net/blay09/mods/waystones/worldgen/ModWorldGen.java
@@ -1,6 +1,5 @@
 package net.blay09.mods.waystones.worldgen;
 
-import com.mojang.datafixers.util.Pair;
 import net.blay09.mods.waystones.Waystones;
 import net.blay09.mods.waystones.block.ModBlocks;
 import net.blay09.mods.waystones.config.WaystonesConfig;
@@ -14,8 +13,9 @@ import net.minecraft.world.gen.GenerationStage;
 import net.minecraft.world.gen.feature.ConfiguredFeature;
 import net.minecraft.world.gen.feature.Feature;
 import net.minecraft.world.gen.feature.NoFeatureConfig;
-import net.minecraft.world.gen.feature.jigsaw.*;
-import net.minecraft.world.gen.feature.structure.*;
+import net.minecraft.world.gen.feature.jigsaw.JigsawPattern;
+import net.minecraft.world.gen.feature.jigsaw.JigsawPiece;
+import net.minecraft.world.gen.feature.jigsaw.LegacySingleJigsawPiece;
 import net.minecraft.world.gen.placement.NoPlacementConfig;
 import net.minecraft.world.gen.placement.Placement;
 import net.minecraftforge.event.world.BiomeLoadingEvent;
@@ -23,7 +23,9 @@ import net.minecraftforge.eventbus.api.SubscribeEvent;
 import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.registries.IForgeRegistry;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
 
 @Mod.EventBusSubscriber(modid = Waystones.MOD_ID)
 public class ModWorldGen {
@@ -98,11 +100,6 @@ public class ModWorldGen {
 
     public static void setupVillageWorldGen(DynamicRegistries dynamicRegistries) {
         if (WaystonesConfig.COMMON.addVillageStructure.get()) {
-            PlainsVillagePools.init();
-            SnowyVillagePools.init();
-            SavannaVillagePools.init();
-            DesertVillagePools.init();
-            TaigaVillagePools.init();
 
             // Add Waystone to Vanilla Villages.
             addWaystoneStructureToVillageConfig(dynamicRegistries, "village/plains/houses", villageWaystoneStructure, 1);

--- a/src/main/resources/META-INF/accesstransformer.cfg
+++ b/src/main/resources/META-INF/accesstransformer.cfg
@@ -3,3 +3,6 @@ public-f net.minecraft.world.gen.feature.jigsaw.JigsawPattern field_214952_d # w
 
 # Needed to access seed from Placement
 public net.minecraft.world.gen.feature.WorldDecoratingHelper field_242889_a # field_242889_a
+
+# Needed to add waystones to vanilla pools
+public-f net.minecraft.world.gen.feature.jigsaw.JigsawPattern field_214953_e #jigsawPieces


### PR DESCRIPTION
I'll try and summarize my changes so you know what's going on and how to work with it. 

So first, I decided to hook into FMLServerAboutToStartEvent so we can grab the DynamicRegistry. This registry is the finalized worldgen registry after datapacks are loaded in. By manipulating the DynamicRegistry after the server read the files, Waystones will still be added to village overhaul datapacks as well now! I didn't know where you register the Forge events so I just stuck it into the Waystone class. You can move it elsewhere if you prefer.

The second thing I did was removed the piece registration stuff as that isn't needed. We can create and add our pieces directly into the pool file (needs 1 AccessTransformer to work). No registration needed.

By using the DynamicRegistry to get the pool and add the Waystones directly to it, you now can easily add Waystone pieces to any mod's jigsaw structure without a hard dependency on the other mods. My mod Repurposed Structures is used as an demonstration of mod compatibility as my road's Jigsaw Blocks already matches the Waystone's Jigsaw Block. For other mod's structures, you may need to make a new nbt file with a Jigsaw Block that connect to theirs's in order for the piece to spawn (and don't forget the line of code to add the piece to their pools).

Vanilla village:
![image](https://user-images.githubusercontent.com/40846040/112074441-aeb7f980-8b4c-11eb-8d30-cb2b169210bc.png)

Repurposed Structures village:
![image](https://user-images.githubusercontent.com/40846040/112075549-1a02cb00-8b4f-11eb-8c67-a22f3f60005e.png)