### PR TITLE
Fix incorrect rune rendering directions

### DIFF
--- a/src/main/java/net/blay09/mods/waystones/client/render/PortstoneRenderer.java
+++ b/src/main/java/net/blay09/mods/waystones/client/render/PortstoneRenderer.java
@@ -20,9 +20,9 @@ import net.minecraft.client.renderer.tileentity.TileEntityRendererDispatcher;
 import net.minecraft.enchantment.Enchantments;
 import net.minecraft.item.ItemStack;
 import net.minecraft.state.properties.DoubleBlockHalf;
-import net.minecraft.util.Direction;
 import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.math.vector.Quaternion;
+import net.minecraft.util.math.vector.Vector3f;
 import net.minecraft.world.World;
 
 public class PortstoneRenderer extends TileEntityRenderer<PortstoneTileEntity> {
@@ -43,7 +43,6 @@ public class PortstoneRenderer extends TileEntityRenderer<PortstoneTileEntity> {
         if (world == null || state.get(PortstoneBlock.HALF) != DoubleBlockHalf.LOWER) {
             return;
         }
-        Direction facing = state.get(PortstoneBlock.FACING);
 
         if (warpStoneItem == null) {
             warpStoneItem = new ItemStack(ModItems.warpStone);
@@ -52,8 +51,8 @@ public class PortstoneRenderer extends TileEntityRenderer<PortstoneTileEntity> {
 
         matrixStack.push();
         matrixStack.translate(0.5f, 0f, 0.5f);
-        matrixStack.rotate(new Quaternion(0f, -facing.getHorizontalAngle(), 0f, true));
-        matrixStack.rotate(new Quaternion(-180f, 0f, 0f, true));
+        matrixStack.rotate(state.get(PortstoneBlock.FACING).getRotation());
+        matrixStack.rotate(Vector3f.XP.rotationDegrees(90f));
         matrixStack.translate(0f, -2f, 0f);
         float scale = 1.01f;
         matrixStack.scale(0.5f, 0.5f, 0.5f);
@@ -70,7 +69,8 @@ public class PortstoneRenderer extends TileEntityRenderer<PortstoneTileEntity> {
 
         matrixStack.push();
         matrixStack.translate(0.5f, 1f, 0.5f);
-        matrixStack.rotate(new Quaternion(0f, -facing.getHorizontalAngle(), 0f, true));
+        matrixStack.rotate(state.get(PortstoneBlock.FACING).getRotation());
+        matrixStack.rotate(Vector3f.XN.rotationDegrees(90f));
         matrixStack.translate(0f, 0f, 0.15f);
         matrixStack.rotate(new Quaternion(-25f, 0f, 0f, true));
         matrixStack.scale(0.5f, 0.5f, 0.5f);

--- a/src/main/java/net/blay09/mods/waystones/client/render/SharestoneRenderer.java
+++ b/src/main/java/net/blay09/mods/waystones/client/render/SharestoneRenderer.java
@@ -23,6 +23,7 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.state.properties.DoubleBlockHalf;
 import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.math.vector.Quaternion;
+import net.minecraft.util.math.vector.Vector3f;
 import net.minecraft.world.World;
 
 public class SharestoneRenderer extends TileEntityRenderer<SharestoneTileEntity> {
@@ -50,7 +51,8 @@ public class SharestoneRenderer extends TileEntityRenderer<SharestoneTileEntity>
         if (color != null) {
             matrixStack.push();
             matrixStack.translate(0.5f, 0f, 0.5f);
-            matrixStack.rotate(new Quaternion(-180f, 0f, 0f, true));
+            matrixStack.rotate(state.get(SharestoneBlock.FACING).getRotation());
+            matrixStack.rotate(Vector3f.XP.rotationDegrees(90f));
             matrixStack.translate(0f, -2f, 0f);
             float scale = 1.01f;
             matrixStack.scale(0.5f, 0.5f, 0.5f);

--- a/src/main/java/net/blay09/mods/waystones/client/render/WaystoneRenderer.java
+++ b/src/main/java/net/blay09/mods/waystones/client/render/WaystoneRenderer.java
@@ -19,7 +19,7 @@ import net.minecraft.client.renderer.tileentity.TileEntityRendererDispatcher;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.state.properties.DoubleBlockHalf;
 import net.minecraft.util.ResourceLocation;
-import net.minecraft.util.math.vector.Quaternion;
+import net.minecraft.util.math.vector.Vector3f;
 
 import java.util.Objects;
 
@@ -39,11 +39,10 @@ public class WaystoneRenderer extends TileEntityRenderer<WaystoneTileEntity> {
             return;
         }
 
-        float angle = state.get(WaystoneBlock.FACING).getHorizontalAngle();
         matrixStack.push();
         matrixStack.translate(0.5f, 0f, 0.5f);
-        matrixStack.rotate(new Quaternion(0f, angle, 0f, true));
-        matrixStack.rotate(new Quaternion(-180f, 0f, 0f, true));
+        matrixStack.rotate(state.get(WaystoneBlock.FACING).getRotation());
+        matrixStack.rotate(Vector3f.XP.rotationDegrees(90f));
         matrixStack.scale(0.5f, 0.5f, 0.5f);
         PlayerEntity player = Minecraft.getInstance().player;
         boolean isActivated = PlayerWaystoneManager.isWaystoneActivated(Objects.requireNonNull(player), tileEntity.getWaystone());


### PR DESCRIPTION
The direction of runes to be rendered should be rotated with the value of the `facing` property for way stones, share stones, and port stones. However:

* The rotation of runes now is opposite to that of way stones: for `facing=south` and `facing=north` it is correct (6 runes in front), but for `facing=east` and `facing=west` directions are completely reversed (7 runes in front).
* There is not any rotation of runes on share stones at all: the runes that should have been in front are always facing south.

The following images are screenshots of correct and incorrect implementations. The directions of netherite swords indicate the value of the `facing` property.

Original implementation:
![image](https://user-images.githubusercontent.com/8004211/122089680-96006c80-ce39-11eb-9c78-1a8cb9941125.png)

Correct implementation fixed by this PR:
![image](https://user-images.githubusercontent.com/8004211/122089838-c1835700-ce39-11eb-8e0b-04684853cd39.png)
