### PR TITLE
Fix placing blocks when right clicking a waystone

### DIFF
--- a/shared/src/java/net/blay09/mods/waystones/block/WaystoneBlock.java
+++ b/shared/src/java/net/blay09/mods/waystones/block/WaystoneBlock.java
@@ -83,6 +83,7 @@ public class WaystoneBlock extends WaystoneBlockBase {
                     player.displayClientMessage(new TranslatableComponent("chat.waystones.waystone_to_waystone_disabled"), true);
                 }
             }
+            return InteractionResult.PASS;
         } else {
             PlayerWaystoneManager.activateWaystone(player, waystone);
 
@@ -106,6 +107,7 @@ public class WaystoneBlock extends WaystoneBlockBase {
                     world.addParticle(ParticleTypes.ENCHANT, pos.getX() + 0.5 + (world.random.nextDouble() - 0.5) * 2, pos.getY() + 4, pos.getZ() + 0.5 + (world.random.nextDouble() - 0.5) * 2, 0, -5, 0);
                 }
             }
+            return InteractionResult.PASS;
         }
 
         return InteractionResult.SUCCESS;


### PR DESCRIPTION
When a player has a block in his hand he will place the block AND open the gui. by returning pass you can stop that.