### PR TITLE
Fix typo in lang key for waypoint activation statistic

### DIFF
--- a/src/main/resources/assets/waystones/lang/en_us.json
+++ b/src/main/resources/assets/waystones/lang/en_us.json
@@ -87,6 +87,6 @@
   "tooltip.waystones.attuned_shard.attunement_lost": "This shard has lost its attunement.",
   "tooltip.waystones.not_enough_xp": "Not enough experience! (%d levels needed)",
   "tooltip.waystones.undiscovered": "Undiscovered",
-  "stat.waystones.waystones_activated": "Waystones Activated",
+  "stat.waystones.waystone_activated": "Waystones Activated",
   "waystones:warp_plate": "Warp Plate"
 }

--- a/src/main/resources/assets/waystones/lang/fr_fr.json
+++ b/src/main/resources/assets/waystones/lang/fr_fr.json
@@ -33,5 +33,5 @@
   "tooltip.waystones.cooldown_left": "Recharge: %d secondes",
   "tooltip.waystones.bound_to": "Lié à: %s",
   "tooltip.waystones.bound_to_none": "Aucune",
-  "stat.waystones.waystones_activated": "Waystones activées"
+  "stat.waystones.waystone_activated": "Waystones activées"
 }

--- a/src/main/resources/assets/waystones/lang/hu_hu.json
+++ b/src/main/resources/assets/waystones/lang/hu_hu.json
@@ -33,5 +33,5 @@
   "tooltip.waystones.cooldown_left": "Visszaszámlálás: %d másodperc",
   "tooltip.waystones.bound_to": "Hozzákötve: %s",
   "tooltip.waystones.bound_to_none": "Semelyikhez",
-  "stat.waystones.waystones_activated": "Aktivált irányoszlopok"
+  "stat.waystones.waystone_activated": "Aktivált irányoszlopok"
 }

--- a/src/main/resources/assets/waystones/lang/ko_kr.json
+++ b/src/main/resources/assets/waystones/lang/ko_kr.json
@@ -40,5 +40,5 @@
   "tooltip.waystones.cooldown_left": "쿨다운: %d초",
   "tooltip.waystones.bound_to": "바운드: %s",
   "tooltip.waystones.bound_to_none": "없음",
-  "stat.waystones.waystones_activated": "웨이스톤 활성화됨"
+  "stat.waystones.waystone_activated": "웨이스톤 활성화됨"
 }

--- a/src/main/resources/assets/waystones/lang/pt_br.json
+++ b/src/main/resources/assets/waystones/lang/pt_br.json
@@ -37,5 +37,5 @@
   "tooltip.waystones.cooldown_left": "Tempo de Recarga: %d segundos",
   "tooltip.waystones.bound_to": "Vinculado a: %s",
   "tooltip.waystones.bound_to_none": "Nenhum",
-  "stat.waystones.waystones_activated": "Obelisco Ativado"
+  "stat.waystones.waystone_activated": "Obelisco Ativado"
 }

--- a/src/main/resources/assets/waystones/lang/ru_ru.json
+++ b/src/main/resources/assets/waystones/lang/ru_ru.json
@@ -33,5 +33,5 @@
   "tooltip.waystones.cooldown_left": "Перезарядка: %d секунд",
   "tooltip.waystones.bound_to": "Привязан: %s",
   "tooltip.waystones.bound_to_none": "Нет",
-  "stat.waystones.waystones_activated": "Обелиск активирован"
+  "stat.waystones.waystone_activated": "Обелиск активирован"
 }

--- a/src/main/resources/assets/waystones/lang/zh_cn.json
+++ b/src/main/resources/assets/waystones/lang/zh_cn.json
@@ -33,5 +33,5 @@
   "tooltip.waystones.cooldown_left": "冷却时间: %d秒",
   "tooltip.waystones.bound_to": "绑定至: %s",
   "tooltip.waystones.bound_to_none": "无",
-  "stat.waystones.waystones_activated": "传送石碑已激活"
+  "stat.waystones.waystone_activated": "传送石碑已激活"
 }


### PR DESCRIPTION
Fixes #420.

The statistics registry key path is defined in ModStats.java:L10 as
"waystone_activated", but all lang files use "waystones_activated".

Already fixed in the zh_tw translation by recently merged PR #390, where
the contributor noticed and corrected the issue independently.