### PR TITLE
add pieces to rawTemplates field for maximum mod compat

### DIFF
--- a/src/main/java/net/blay09/mods/waystones/worldgen/ModWorldGen.java
+++ b/src/main/java/net/blay09/mods/waystones/worldgen/ModWorldGen.java
@@ -1,5 +1,6 @@
 package net.blay09.mods.waystones.worldgen;
 
+import com.mojang.datafixers.util.Pair;
 import net.blay09.mods.waystones.Waystones;
 import net.blay09.mods.waystones.block.ModBlocks;
 import net.blay09.mods.waystones.config.WaystonesConfig;
@@ -129,6 +130,10 @@ public class ModWorldGen {
                 listOfPieces.add(piece);
             }
             pool.jigsawPieces = listOfPieces;
+
+            List<Pair<JigsawPiece, Integer>> listOfWeightedPieces = new ArrayList<>(pool.rawTemplates);
+            listOfWeightedPieces.add(new Pair(piece, weight));
+            pool.rawTemplates = listOfWeightedPieces;
         }
     }
 }


### PR DESCRIPTION
Some mods may read the rawTemplates field instead of the templates field because rawTemplates is a weighted list and can be easier to use than the templates field. (example, my repurposed structures mod)

Just a small addition that doesn't change the functionality of your mod in-game but is for more consistency and helps other mods find your pieces with its weight to use.

(this is for 1.16.x branch. Same code can be easily ported to 1.17.x)