### PR TITLE
Covert RS compat code to use RS json

### DIFF
--- a/shared/src/main/java/net/blay09/mods/waystones/worldgen/ModWorldGen.java
+++ b/shared/src/main/java/net/blay09/mods/waystones/worldgen/ModWorldGen.java
@@ -68,6 +68,13 @@ public class ModWorldGen {
 
         Balm.getEvents().onEvent(ServerStartedEvent.class, event -> setupVillageWorldGen(event.getServer().registryAccess()));
         Balm.getEvents().onEvent(ServerReloadedEvent.class, event -> setupVillageWorldGen(event.getServer().registryAccess()));
+
+        // Registers a condition for repurposed structures compat
+        Registry.REGISTRY.getOptional(new ResourceLocation("repurposed_structures", "json_conditions"))
+            .ifPresent(registry -> Registry.register(
+                (Registry<Supplier<Boolean>>)registry,
+                new ResourceLocation("waystones", "config"),
+                () -> WaystonesConfig.getActive().spawnInVillages() || WaystonesConfig.getActive().forceSpawnInVillages()));
     }
 
     private static BiomePredicate matchesCategory(Biome.BiomeCategory category) {
@@ -113,13 +120,6 @@ public class ModWorldGen {
             addWaystoneStructureToVillageConfig(registryAccess, "village/desert/houses", desertVillageWaystoneStructure, 1);
             addWaystoneStructureToVillageConfig(registryAccess, "village/taiga/houses", villageWaystoneStructure, 1);
         }
-
-        // Registers a condition for repurposed structures compat
-        Registry.REGISTRY.getOptional(new ResourceLocation("repurposed_structures", "json_conditions"))
-            .ifPresent(registry -> Registry.register(
-                (Registry<Supplier<Boolean>>)registry,
-                new ResourceLocation("waystones", "config"),
-                () -> WaystonesConfig.getActive().spawnInVillages() || WaystonesConfig.getActive().forceSpawnInVillages()));
     }
 
     private static void addWaystoneStructureToVillageConfig(RegistryAccess registryAccess, String villagePiece, ResourceLocation waystoneStructure, int weight) {

--- a/shared/src/main/java/net/blay09/mods/waystones/worldgen/ModWorldGen.java
+++ b/shared/src/main/java/net/blay09/mods/waystones/worldgen/ModWorldGen.java
@@ -112,18 +112,14 @@ public class ModWorldGen {
             addWaystoneStructureToVillageConfig(registryAccess, "village/savanna/houses", villageWaystoneStructure, 1);
             addWaystoneStructureToVillageConfig(registryAccess, "village/desert/houses", desertVillageWaystoneStructure, 1);
             addWaystoneStructureToVillageConfig(registryAccess, "village/taiga/houses", villageWaystoneStructure, 1);
-
-            // Add Waystone to other mod's structures. (Make sure Waystone piece Jigsaw Block's Name matches the other mod piece Jigsaw's Target Name.
-            addWaystoneStructureToVillageConfig(registryAccess, "repurposed_structures:villages/badlands/houses", desertVillageWaystoneStructure, 1);
-            addWaystoneStructureToVillageConfig(registryAccess, "repurposed_structures:villages/birch/houses", villageWaystoneStructure, 1);
-            addWaystoneStructureToVillageConfig(registryAccess, "repurposed_structures:villages/dark_forest/houses", villageWaystoneStructure, 1);
-            addWaystoneStructureToVillageConfig(registryAccess, "repurposed_structures:villages/giant_taiga/houses", villageWaystoneStructure, 1);
-            addWaystoneStructureToVillageConfig(registryAccess, "repurposed_structures:villages/jungle/houses", villageWaystoneStructure, 1);
-            addWaystoneStructureToVillageConfig(registryAccess, "repurposed_structures:villages/mountains/houses", villageWaystoneStructure, 1);
-            addWaystoneStructureToVillageConfig(registryAccess, "repurposed_structures:villages/mushroom/houses", villageWaystoneStructure, 1);
-            addWaystoneStructureToVillageConfig(registryAccess, "repurposed_structures:villages/oak/houses", villageWaystoneStructure, 1);
-            addWaystoneStructureToVillageConfig(registryAccess, "repurposed_structures:villages/swamp/houses", villageWaystoneStructure, 1);
         }
+
+        // Registers a condition for repurposed structures compat
+        Registry.REGISTRY.getOptional(new ResourceLocation("repurposed_structures", "json_conditions"))
+            .ifPresent(registry -> Registry.register(
+                (Registry<Supplier<Boolean>>)registry,
+                new ResourceLocation("waystones", "config"),
+                () -> WaystonesConfig.getActive().spawnInVillages() || WaystonesConfig.getActive().forceSpawnInVillages()));
     }
 
     private static void addWaystoneStructureToVillageConfig(RegistryAccess registryAccess, String villagePiece, ResourceLocation waystoneStructure, int weight) {

--- a/shared/src/main/resources/data/repurposed_structures/pool_additions/villages/badlands/houses.json
+++ b/shared/src/main/resources/data/repurposed_structures/pool_additions/villages/badlands/houses.json
@@ -1,0 +1,16 @@
+{
+  "name": "repurposed_structures:villages/badlands/houses",
+  "fallback": "repurposed_structures:villages/badlands/terminators",
+  "elements": [
+    {
+      "weight": 3,
+      "element": {
+        "location": "waystones:village/desert/waystone",
+        "processors": "minecraft:empty",
+        "projection": "rigid",
+        "element_type": "minecraft:legacy_single_pool_element"
+      },
+	  "condition": "waystones:config"
+    }
+  ]
+}

--- a/shared/src/main/resources/data/repurposed_structures/pool_additions/villages/badlands/houses.json
+++ b/shared/src/main/resources/data/repurposed_structures/pool_additions/villages/badlands/houses.json
@@ -10,7 +10,7 @@
         "projection": "rigid",
         "element_type": "minecraft:legacy_single_pool_element"
       },
-	  "condition": "waystones:config"
+      "condition": "waystones:config"
     }
   ]
 }

--- a/shared/src/main/resources/data/repurposed_structures/pool_additions/villages/birch/houses.json
+++ b/shared/src/main/resources/data/repurposed_structures/pool_additions/villages/birch/houses.json
@@ -10,7 +10,7 @@
         "projection": "rigid",
         "element_type": "minecraft:legacy_single_pool_element"
       },
-	  "condition": "waystones:config"
+      "condition": "waystones:config"
     }
   ]
 }

--- a/shared/src/main/resources/data/repurposed_structures/pool_additions/villages/birch/houses.json
+++ b/shared/src/main/resources/data/repurposed_structures/pool_additions/villages/birch/houses.json
@@ -1,0 +1,16 @@
+{
+  "name": "repurposed_structures:villages/birch/houses",
+  "fallback": "repurposed_structures:villages/birch/terminators",
+  "elements": [
+    {
+      "weight": 3,
+      "element": {
+        "location": "waystones:village/common/waystone",
+        "processors": "minecraft:empty",
+        "projection": "rigid",
+        "element_type": "minecraft:legacy_single_pool_element"
+      },
+	  "condition": "waystones:config"
+    }
+  ]
+}

--- a/shared/src/main/resources/data/repurposed_structures/pool_additions/villages/dark_forest/houses.json
+++ b/shared/src/main/resources/data/repurposed_structures/pool_additions/villages/dark_forest/houses.json
@@ -10,7 +10,7 @@
         "projection": "rigid",
         "element_type": "minecraft:legacy_single_pool_element"
       },
-	  "condition": "waystones:config"
+      "condition": "waystones:config"
     }
   ]
 }

--- a/shared/src/main/resources/data/repurposed_structures/pool_additions/villages/dark_forest/houses.json
+++ b/shared/src/main/resources/data/repurposed_structures/pool_additions/villages/dark_forest/houses.json
@@ -1,0 +1,16 @@
+{
+  "name": "repurposed_structures:villages/dark_forest/houses",
+  "fallback": "repurposed_structures:villages/dark_forest/terminators",
+  "elements": [
+    {
+      "weight": 3,
+      "element": {
+        "location": "waystones:village/common/waystone",
+        "processors": "minecraft:empty",
+        "projection": "rigid",
+        "element_type": "minecraft:legacy_single_pool_element"
+      },
+	  "condition": "waystones:config"
+    }
+  ]
+}

--- a/shared/src/main/resources/data/repurposed_structures/pool_additions/villages/giant_taiga/houses.json
+++ b/shared/src/main/resources/data/repurposed_structures/pool_additions/villages/giant_taiga/houses.json
@@ -10,7 +10,7 @@
         "projection": "rigid",
         "element_type": "minecraft:legacy_single_pool_element"
       },
-	  "condition": "waystones:config"
+      "condition": "waystones:config"
     }
   ]
 }

--- a/shared/src/main/resources/data/repurposed_structures/pool_additions/villages/giant_taiga/houses.json
+++ b/shared/src/main/resources/data/repurposed_structures/pool_additions/villages/giant_taiga/houses.json
@@ -1,0 +1,16 @@
+{
+  "name": "repurposed_structures:villages/giant_taiga/houses",
+  "fallback": "repurposed_structures:villages/giant_taiga/terminators",
+  "elements": [
+    {
+      "weight": 3,
+      "element": {
+        "location": "waystones:village/common/waystone",
+        "processors": "minecraft:empty",
+        "projection": "rigid",
+        "element_type": "minecraft:legacy_single_pool_element"
+      },
+	  "condition": "waystones:config"
+    }
+  ]
+}

--- a/shared/src/main/resources/data/repurposed_structures/pool_additions/villages/jungle/houses.json
+++ b/shared/src/main/resources/data/repurposed_structures/pool_additions/villages/jungle/houses.json
@@ -1,0 +1,16 @@
+{
+  "name": "repurposed_structures:villages/jungle/houses",
+  "fallback": "repurposed_structures:villages/jungle/terminators",
+  "elements": [
+    {
+      "weight": 3,
+      "element": {
+        "location": "waystones:village/common/waystone",
+        "processors": "minecraft:empty",
+        "projection": "rigid",
+        "element_type": "minecraft:legacy_single_pool_element"
+      },
+	  "condition": "waystones:config"
+    }
+  ]
+}

--- a/shared/src/main/resources/data/repurposed_structures/pool_additions/villages/jungle/houses.json
+++ b/shared/src/main/resources/data/repurposed_structures/pool_additions/villages/jungle/houses.json
@@ -10,7 +10,7 @@
         "projection": "rigid",
         "element_type": "minecraft:legacy_single_pool_element"
       },
-	  "condition": "waystones:config"
+      "condition": "waystones:config"
     }
   ]
 }

--- a/shared/src/main/resources/data/repurposed_structures/pool_additions/villages/mountains/houses.json
+++ b/shared/src/main/resources/data/repurposed_structures/pool_additions/villages/mountains/houses.json
@@ -1,0 +1,16 @@
+{
+  "name": "repurposed_structures:villages/mountains/houses",
+  "fallback": "repurposed_structures:villages/mountains/terminators",
+  "elements": [
+    {
+      "weight": 3,
+      "element": {
+        "location": "waystones:village/common/waystone",
+        "processors": "minecraft:empty",
+        "projection": "rigid",
+        "element_type": "minecraft:legacy_single_pool_element"
+      },
+	  "condition": "waystones:config"
+    }
+  ]
+}

--- a/shared/src/main/resources/data/repurposed_structures/pool_additions/villages/mountains/houses.json
+++ b/shared/src/main/resources/data/repurposed_structures/pool_additions/villages/mountains/houses.json
@@ -10,7 +10,7 @@
         "projection": "rigid",
         "element_type": "minecraft:legacy_single_pool_element"
       },
-	  "condition": "waystones:config"
+      "condition": "waystones:config"
     }
   ]
 }

--- a/shared/src/main/resources/data/repurposed_structures/pool_additions/villages/mushroom/houses.json
+++ b/shared/src/main/resources/data/repurposed_structures/pool_additions/villages/mushroom/houses.json
@@ -10,7 +10,7 @@
         "projection": "rigid",
         "element_type": "minecraft:legacy_single_pool_element"
       },
-	  "condition": "waystones:config"
+      "condition": "waystones:config"
     }
   ]
 }

--- a/shared/src/main/resources/data/repurposed_structures/pool_additions/villages/mushroom/houses.json
+++ b/shared/src/main/resources/data/repurposed_structures/pool_additions/villages/mushroom/houses.json
@@ -1,0 +1,16 @@
+{
+  "name": "repurposed_structures:villages/mushroom/houses",
+  "fallback": "repurposed_structures:villages/mushroom/terminators",
+  "elements": [
+    {
+      "weight": 3,
+      "element": {
+        "location": "waystones:village/common/waystone",
+        "processors": "minecraft:empty",
+        "projection": "rigid",
+        "element_type": "minecraft:legacy_single_pool_element"
+      },
+	  "condition": "waystones:config"
+    }
+  ]
+}

--- a/shared/src/main/resources/data/repurposed_structures/pool_additions/villages/oak/houses.json
+++ b/shared/src/main/resources/data/repurposed_structures/pool_additions/villages/oak/houses.json
@@ -1,0 +1,16 @@
+{
+  "name": "repurposed_structures:villages/oak/houses",
+  "fallback": "repurposed_structures:villages/oak/terminators",
+  "elements": [
+    {
+      "weight": 3,
+      "element": {
+        "location": "waystones:village/common/waystone",
+        "processors": "minecraft:empty",
+        "projection": "rigid",
+        "element_type": "minecraft:legacy_single_pool_element"
+      },
+	  "condition": "waystones:config"
+    }
+  ]
+}

--- a/shared/src/main/resources/data/repurposed_structures/pool_additions/villages/oak/houses.json
+++ b/shared/src/main/resources/data/repurposed_structures/pool_additions/villages/oak/houses.json
@@ -10,7 +10,7 @@
         "projection": "rigid",
         "element_type": "minecraft:legacy_single_pool_element"
       },
-	  "condition": "waystones:config"
+      "condition": "waystones:config"
     }
   ]
 }

--- a/shared/src/main/resources/data/repurposed_structures/pool_additions/villages/swamp/houses.json
+++ b/shared/src/main/resources/data/repurposed_structures/pool_additions/villages/swamp/houses.json
@@ -1,0 +1,16 @@
+{
+  "name": "repurposed_structures:villages/swamp/houses",
+  "fallback": "repurposed_structures:villages/swamp/terminators",
+  "elements": [
+    {
+      "weight": 3,
+      "element": {
+        "location": "waystones:village/common/waystone",
+        "processors": "minecraft:empty",
+        "projection": "rigid",
+        "element_type": "minecraft:legacy_single_pool_element"
+      },
+	  "condition": "waystones:config"
+    }
+  ]
+}

--- a/shared/src/main/resources/data/repurposed_structures/pool_additions/villages/swamp/houses.json
+++ b/shared/src/main/resources/data/repurposed_structures/pool_additions/villages/swamp/houses.json
@@ -10,7 +10,7 @@
         "projection": "rigid",
         "element_type": "minecraft:legacy_single_pool_element"
       },
-	  "condition": "waystones:config"
+      "condition": "waystones:config"
     }
   ]
 }

--- a/shared/src/main/resources/data/repurposed_structures/rs_pieces_spawn_counts_additions/village_badlands.json
+++ b/shared/src/main/resources/data/repurposed_structures/rs_pieces_spawn_counts_additions/village_badlands.json
@@ -1,0 +1,10 @@
+{
+  "pieces_spawn_counts": [
+    {
+      "nbt_piece_name": "waystones:village/desert/waystone",
+      "always_spawn_this_many": 1,
+      "never_spawn_more_than_this_many": 1,
+      "condition": "waystones:config"
+    }
+  ]
+}

--- a/shared/src/main/resources/data/repurposed_structures/rs_pieces_spawn_counts_additions/village_birch.json
+++ b/shared/src/main/resources/data/repurposed_structures/rs_pieces_spawn_counts_additions/village_birch.json
@@ -1,0 +1,10 @@
+{
+  "pieces_spawn_counts": [
+    {
+      "nbt_piece_name": "waystones:village/common/waystone",
+      "always_spawn_this_many": 1,
+      "never_spawn_more_than_this_many": 1,
+      "condition": "waystones:config"
+    }
+  ]
+}

--- a/shared/src/main/resources/data/repurposed_structures/rs_pieces_spawn_counts_additions/village_dark_forest.json
+++ b/shared/src/main/resources/data/repurposed_structures/rs_pieces_spawn_counts_additions/village_dark_forest.json
@@ -1,0 +1,10 @@
+{
+  "pieces_spawn_counts": [
+    {
+      "nbt_piece_name": "waystones:village/common/waystone",
+      "always_spawn_this_many": 1,
+      "never_spawn_more_than_this_many": 1,
+      "condition": "waystones:config"
+    }
+  ]
+}

--- a/shared/src/main/resources/data/repurposed_structures/rs_pieces_spawn_counts_additions/village_giant_taiga.json
+++ b/shared/src/main/resources/data/repurposed_structures/rs_pieces_spawn_counts_additions/village_giant_taiga.json
@@ -1,0 +1,10 @@
+{
+  "pieces_spawn_counts": [
+    {
+      "nbt_piece_name": "waystones:village/common/waystone",
+      "always_spawn_this_many": 1,
+      "never_spawn_more_than_this_many": 1,
+      "condition": "waystones:config"
+    }
+  ]
+}

--- a/shared/src/main/resources/data/repurposed_structures/rs_pieces_spawn_counts_additions/village_jungle.json
+++ b/shared/src/main/resources/data/repurposed_structures/rs_pieces_spawn_counts_additions/village_jungle.json
@@ -1,0 +1,10 @@
+{
+  "pieces_spawn_counts": [
+    {
+      "nbt_piece_name": "waystones:village/common/waystone",
+      "always_spawn_this_many": 1,
+      "never_spawn_more_than_this_many": 1,
+      "condition": "waystones:config"
+    }
+  ]
+}

--- a/shared/src/main/resources/data/repurposed_structures/rs_pieces_spawn_counts_additions/village_mountains.json
+++ b/shared/src/main/resources/data/repurposed_structures/rs_pieces_spawn_counts_additions/village_mountains.json
@@ -1,0 +1,10 @@
+{
+  "pieces_spawn_counts": [
+    {
+      "nbt_piece_name": "waystones:village/common/waystone",
+      "always_spawn_this_many": 1,
+      "never_spawn_more_than_this_many": 1,
+      "condition": "waystones:config"
+    }
+  ]
+}

--- a/shared/src/main/resources/data/repurposed_structures/rs_pieces_spawn_counts_additions/village_mushroom.json
+++ b/shared/src/main/resources/data/repurposed_structures/rs_pieces_spawn_counts_additions/village_mushroom.json
@@ -1,0 +1,10 @@
+{
+  "pieces_spawn_counts": [
+    {
+      "nbt_piece_name": "waystones:village/common/waystone",
+      "always_spawn_this_many": 1,
+      "never_spawn_more_than_this_many": 1,
+      "condition": "waystones:config"
+    }
+  ]
+}

--- a/shared/src/main/resources/data/repurposed_structures/rs_pieces_spawn_counts_additions/village_oak.json
+++ b/shared/src/main/resources/data/repurposed_structures/rs_pieces_spawn_counts_additions/village_oak.json
@@ -1,0 +1,10 @@
+{
+  "pieces_spawn_counts": [
+    {
+      "nbt_piece_name": "waystones:village/common/waystone",
+      "always_spawn_this_many": 1,
+      "never_spawn_more_than_this_many": 1,
+      "condition": "waystones:config"
+    }
+  ]
+}

--- a/shared/src/main/resources/data/repurposed_structures/rs_pieces_spawn_counts_additions/village_swamp.json
+++ b/shared/src/main/resources/data/repurposed_structures/rs_pieces_spawn_counts_additions/village_swamp.json
@@ -1,0 +1,10 @@
+{
+  "pieces_spawn_counts": [
+    {
+      "nbt_piece_name": "waystones:village/common/waystone",
+      "always_spawn_this_many": 1,
+      "never_spawn_more_than_this_many": 1,
+      "condition": "waystones:config"
+    }
+  ]
+}


### PR DESCRIPTION
This should help reduce amount of code you need for RS compat and makes it json that others can override with datapacks.

I noticed that Waystones uses mixins into the vanilla jigsaw assembly for the forceInVillages config but that has no effect on RS as I use my own assembly class. So with this PR, I have `"always_spawn_this_many": 1,` and `"never_spawn_more_than_this_many": 1,` in the rs compat json so every rs village always has a waystone. You can remove the always_spawn_this_many from the json to make it not forced anymore.

The `"condition": "waystones:config"` determines if RS should read the json file or not. The only code needed is for registering your own condition with your config which is done in this PR already so that your configs still can turn on or off the RS compat.

I think that's pretty much it. I couldn't test the PR due to github requiring auth for downloading Balm so I did this pr as best I can without being able to test. It should be good as this is basically a copy of how I had Fabric Waystones do this compat with RS json files.

The perk of this PR is that users can override the json with datapacks to change the rates of waystones per RS villages, remove from certain villages, or change how many waystones spawn or not. 