### PR TITLE
Fix logspam about missing processor values and potential later chunk nbt issues

### DIFF
--- a/shared/src/main/java/net/blay09/mods/waystones/worldgen/ModWorldGen.java
+++ b/shared/src/main/java/net/blay09/mods/waystones/worldgen/ModWorldGen.java
@@ -35,6 +35,7 @@ import java.util.function.Supplier;
 public class ModWorldGen {
     private static final ResourceLocation villageWaystoneStructure = new ResourceLocation("waystones", "village/common/waystone");
     private static final ResourceLocation desertVillageWaystoneStructure = new ResourceLocation("waystones", "village/desert/waystone");
+    private static final ResourceKey<StructureProcessorList> EMPTY_PROCESSOR_LIST_KEY = ResourceKey.create(Registry.PROCESSOR_LIST_REGISTRY, new ResourceLocation("minecraft", "empty"));
 
     private static DeferredObject<WaystoneFeature> waystoneFeature;
     private static DeferredObject<WaystoneFeature> mossyWaystoneFeature;
@@ -125,7 +126,9 @@ public class ModWorldGen {
     }
 
     private static void addWaystoneStructureToVillageConfig(RegistryAccess registryAccess, String villagePiece, ResourceLocation waystoneStructure, int weight) {
-        LegacySinglePoolElement piece = StructurePoolElement.legacy(waystoneStructure.toString()).apply(StructureTemplatePool.Projection.RIGID);
+
+        Holder<StructureProcessorList> emptyProcessorList = registryAccess.registryOrThrow(Registry.PROCESSOR_LIST_REGISTRY).getHolderOrThrow(EMPTY_PROCESSOR_LIST_KEY);
+        LegacySinglePoolElement piece = StructurePoolElement.legacy(waystoneStructure.toString(), emptyProcessorList).apply(StructureTemplatePool.Projection.RIGID);
         StructureTemplatePool pool = registryAccess.registryOrThrow(Registry.TEMPLATE_POOL_REGISTRY).getOptional(new ResourceLocation(villagePiece)).orElse(null);
         if (pool != null) {
             var poolAccessor = (StructureTemplatePoolAccessor) pool;


### PR DESCRIPTION
The .legacy(<string>) method will use the static field that holds an empty processor list. The issue is, this instance of the empty processor does not exist in the dynamic registry that the world uses. So when the game goes to save the structure piece data to the chunk's nbt, it reaches the waystone's piece's processor, cannot convert it to a resource location since it doesn't exist in the dynamic registry, and then start throwing errors. 

So this PR instead will use .legacy(<string>, <Holder<StructureProcessorLists>>) method where the structure processor we use is the one from the dynamic registry that's actually being used. This will make the waystone piece be saved to nbt without errors.

This issue also plagued the Fabric Waystones mod and I helped them fix it too. Then I heard from players that this Waystone mod had the same errors which leads me here with this PR to help.
https://github.com/LordDeatHunter/FabricWaystones/pull/116/files#diff-696895e36a4e354faa490e21546f94f24dc729b59e261d287c1ed033261c332cR73

Sees to be a recurring issue. My gist for adding new pieces to villages was updated to help make sure people use the correct processor list instance going forward for 1.18.2+
https://gist.github.com/TelepathicGrunt/4fdbc445ebcbcbeb43ac748f4b18f342