### PR TITLE
(1.18.X) Add waystone tags

### DIFF
--- a/src/main/resources/data/waystones/tags/blocks/sharestone.json
+++ b/src/main/resources/data/waystones/tags/blocks/sharestone.json
@@ -1,0 +1,22 @@
+{
+  "replace": false,
+  "values": [
+    "waystones:sharestone",
+    "waystones:white_sharestone",
+    "waystones:orange_sharestone",
+    "waystones:magenta_sharestone",
+    "waystones:light_blue_sharestone",
+    "waystones:yellow_sharestone",
+    "waystones:lime_sharestone",
+    "waystones:pink_sharestone",
+    "waystones:gray_sharestone",
+    "waystones:light_gray_sharestone",
+    "waystones:cyan_sharestone",
+    "waystones:purple_sharestone",
+    "waystones:blue_sharestone",
+    "waystones:brown_sharestone",
+    "waystones:green_sharestone",
+    "waystones:red_sharestone",
+    "waystones:black_sharestone"
+  ]
+}

--- a/src/main/resources/data/waystones/tags/blocks/waystone.json
+++ b/src/main/resources/data/waystones/tags/blocks/waystone.json
@@ -1,0 +1,8 @@
+{
+  "replace": false,
+  "values": [
+    "waystones:waystone",
+    "waystones:mossy_waystone",
+    "waystones:sandy_waystone"
+  ]
+}


### PR DESCRIPTION
This PR adds block tags to waystones and sharestones, which may be used by other mods to check if a block is a waystone. (an example is [SectionProtection](https://github.com/Matyrobbrt/SectionProtection/blob/main/src/main/resources/data/sectionprotection/tags/blocks/allow_interaction.json) which wants to check if a block is a waystone to allow interactions with waystones inside claimed chunks)