### PR TITLE
1.19.x fix picking up warp plate items while attuning

### DIFF
--- a/shared/src/main/java/net/blay09/mods/waystones/block/entity/WarpPlateBlockEntity.java
+++ b/shared/src/main/java/net/blay09/mods/waystones/block/entity/WarpPlateBlockEntity.java
@@ -83,23 +83,6 @@ public class WarpPlateBlockEntity extends WaystoneBlockEntityBase implements Imp
     }
 
     @Override
-    public ItemStack removeItem(int slot, int count) {
-        if (!completedFirstAttunement) {
-            return ItemStack.EMPTY;
-        }
-        return ImplementedContainer.super.removeItem(slot, count);
-    }
-
-    @Override
-    public ItemStack removeItemNoUpdate(int slot) {
-        if (!completedFirstAttunement) {
-            return ItemStack.EMPTY;
-        }
-
-        return ImplementedContainer.super.removeItemNoUpdate(slot);
-    }
-
-    @Override
     public void initializeFromExisting(ServerLevelAccessor world, Waystone existingWaystone, ItemStack itemStack) {
         super.initializeFromExisting(world, existingWaystone, itemStack);
 

--- a/shared/src/main/java/net/blay09/mods/waystones/menu/WarpPlateContainer.java
+++ b/shared/src/main/java/net/blay09/mods/waystones/menu/WarpPlateContainer.java
@@ -23,11 +23,36 @@ public class WarpPlateContainer extends AbstractContainerMenu {
 
         checkContainerDataCount(containerData, 1);
 
-        addSlot(new Slot(warpPlate, 0, 80, 45));
-        addSlot(new Slot(warpPlate, 1, 80, 17));
-        addSlot(new Slot(warpPlate, 2, 108, 45));
-        addSlot(new Slot(warpPlate, 3, 80, 73));
-        addSlot(new Slot(warpPlate, 4, 52, 45));
+        addSlot(new Slot(warpPlate, 0, 80, 45) {
+            @Override
+            public boolean mayPickup(Player $$0) {
+                return warpPlate.isCompletedFirstAttunement() && super.mayPickup($$0);
+            }
+        });
+        addSlot(new Slot(warpPlate, 1, 80, 17) {
+            @Override
+            public boolean mayPickup(Player $$0) {
+                return warpPlate.isCompletedFirstAttunement() && super.mayPickup($$0);
+            }
+        });
+        addSlot(new Slot(warpPlate, 2, 108, 45) {
+            @Override
+            public boolean mayPickup(Player $$0) {
+                return warpPlate.isCompletedFirstAttunement() && super.mayPickup($$0);
+            }
+        });
+        addSlot(new Slot(warpPlate, 3, 80, 73) {
+            @Override
+            public boolean mayPickup(Player $$0) {
+                return warpPlate.isCompletedFirstAttunement() && super.mayPickup($$0);
+            }
+        });
+        addSlot(new Slot(warpPlate, 4, 52, 45) {
+            @Override
+            public boolean mayPickup(Player $$0) {
+                return warpPlate.isCompletedFirstAttunement() && super.mayPickup($$0);
+            }
+        });
 
         for (int i = 0; i < 3; ++i) {
             for (int j = 0; j < 9; ++j) {


### PR DESCRIPTION
This PR closes: #604 

By adding the proper check in the container, to disallow the pickup (by left-clicking or shift + left clicking), while the items is attuning.