### PR TITLE
Limit the size of stacks than can be placed in a Warp Plate

### DIFF
--- a/shared/src/main/java/net/blay09/mods/waystones/block/entity/WarpPlateBlockEntity.java
+++ b/shared/src/main/java/net/blay09/mods/waystones/block/entity/WarpPlateBlockEntity.java
@@ -8,7 +8,6 @@ import net.blay09.mods.waystones.block.WarpPlateBlock;
 import net.blay09.mods.waystones.config.WaystonesConfig;
 import net.blay09.mods.waystones.menu.WarpPlateContainer;
 import net.blay09.mods.waystones.core.*;
-import net.blay09.mods.waystones.item.AttunedShardItem;
 import net.blay09.mods.waystones.item.ModItems;
 import net.blay09.mods.waystones.worldgen.namegen.NameGenerationMode;
 import net.blay09.mods.waystones.worldgen.namegen.NameGenerator;
@@ -32,6 +31,7 @@ import net.minecraft.world.entity.player.Inventory;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.inventory.AbstractContainerMenu;
 import net.minecraft.world.inventory.ContainerData;
+import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.Items;
 import net.minecraft.world.level.ServerLevelAccessor;
@@ -207,7 +207,7 @@ public class WarpPlateBlockEntity extends WaystoneBlockEntityBase implements Imp
                 WaystonesAPI.setBoundWaystone(attunedShard, getWaystone());
                 setItem(0, attunedShard);
                 for (int i = 1; i <= 4; i++) {
-                    setItem(i, ItemStack.EMPTY);
+                    getItem(i).shrink(1);
                 }
                 completedFirstAttunement = true;
             }
@@ -393,5 +393,13 @@ public class WarpPlateBlockEntity extends WaystoneBlockEntityBase implements Imp
 
     public ContainerData getContainerData() {
         return dataAccess;
+    }
+
+    @Override
+    public boolean canPlaceItem(int index, ItemStack stack) {
+        if (index == 0 && !getItem(0).isEmpty()) {
+            return false; //prevents hoppers to add items in an occupied center slot
+        }
+        return ImplementedContainer.super.canPlaceItem(index, stack);
     }
 }

--- a/shared/src/main/java/net/blay09/mods/waystones/menu/WarpPlateAttunementSlot.java
+++ b/shared/src/main/java/net/blay09/mods/waystones/menu/WarpPlateAttunementSlot.java
@@ -3,6 +3,7 @@ package net.blay09.mods.waystones.menu;
 import net.blay09.mods.waystones.block.entity.WarpPlateBlockEntity;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.inventory.Slot;
+import net.minecraft.world.item.ItemStack;
 
 public class WarpPlateAttunementSlot extends Slot {
     private final WarpPlateBlockEntity warpPlate;
@@ -15,5 +16,13 @@ public class WarpPlateAttunementSlot extends Slot {
     @Override
     public boolean mayPickup(Player player) {
         return warpPlate.isCompletedFirstAttunement() && super.mayPickup(player);
+    }
+
+    @Override
+    public int getMaxStackSize(ItemStack stack) {
+        if (this.getContainerSlot() == 0) {
+            return 1;
+        }
+        return stack.getMaxStackSize();
     }
 }

--- a/shared/src/main/java/net/blay09/mods/waystones/menu/WarpPlateContainer.java
+++ b/shared/src/main/java/net/blay09/mods/waystones/menu/WarpPlateContainer.java
@@ -63,8 +63,18 @@ public class WarpPlateContainer extends AbstractContainerMenu {
                 if (!this.moveItemStackTo(slotStack, 5, this.slots.size(), true)) {
                     return ItemStack.EMPTY;
                 }
-            } else if (!this.moveItemStackTo(slotStack, 0, 5, false)) {
-                return ItemStack.EMPTY;
+            }
+            else {
+                if (!getSlot(0).hasItem()) {
+                    if (!this.moveItemStackTo(slotStack.split(1), 0, 1, false)) {
+                        return ItemStack.EMPTY;
+                    }
+                }
+                else {
+                    if (!this.moveItemStackTo(slotStack, 1, 5, false)) {
+                        return ItemStack.EMPTY;
+                    }
+                }
             }
 
             if (slotStack.isEmpty()) {


### PR DESCRIPTION
Also limits the acceptable items that may be placed in each of the Warp Plate slots to be consistent with the pseudo-recipes.

Fixes gh-739