### PR TITLE
Prefer setter in IWaystoneTeleportContext to decide to consume warpItem

### DIFF
--- a/shared/src/main/java/net/blay09/mods/waystones/api/IWaystoneTeleportContext.java
+++ b/shared/src/main/java/net/blay09/mods/waystones/api/IWaystoneTeleportContext.java
@@ -7,6 +7,8 @@ import net.minecraft.world.item.ItemStack;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.List;
+import java.util.function.BiPredicate;
+import java.util.function.Predicate;
 
 public interface IWaystoneTeleportContext {
     Entity getEntity();
@@ -52,4 +54,16 @@ public interface IWaystoneTeleportContext {
     boolean playsEffect();
 
     void setPlaysEffect(boolean playsEffect);
+
+    default Predicate<? super ItemStack> getConsumeItemPredicate() {
+        return stack -> getWarpMode().consumesItem();
+    };
+
+    default void setConsumeItemPredicate(Predicate<? super ItemStack> predicate) { }
+
+    default BiPredicate<? super Entity, ? super IWaystone> getAllowTeleportPredicate() {
+        return getWarpMode().getAllowTeleportPredicate();
+    }
+
+    default void setAllowTeleportPredicate(BiPredicate<? super Entity, ? super IWaystone> allowTeleportPredicate) { }
 }

--- a/shared/src/main/java/net/blay09/mods/waystones/api/IWaystoneTeleportContext.java
+++ b/shared/src/main/java/net/blay09/mods/waystones/api/IWaystoneTeleportContext.java
@@ -53,10 +53,10 @@ public interface IWaystoneTeleportContext {
 
     void setPlaysEffect(boolean playsEffect);
 
-    default boolean isWarpItemConsumed() {
+    default boolean consumesWarpItem() {
         return getWarpMode() != null && getWarpMode().consumesItem();
     };
 
-    default void setWarpItemConsumed(boolean isWarpItemConsumed) { }
+    default void setConsumesWarpItem(boolean consumesWarpItem) { }
 
 }

--- a/shared/src/main/java/net/blay09/mods/waystones/api/IWaystoneTeleportContext.java
+++ b/shared/src/main/java/net/blay09/mods/waystones/api/IWaystoneTeleportContext.java
@@ -7,8 +7,6 @@ import net.minecraft.world.item.ItemStack;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.List;
-import java.util.function.BiPredicate;
-import java.util.function.Predicate;
 
 public interface IWaystoneTeleportContext {
     Entity getEntity();
@@ -55,15 +53,10 @@ public interface IWaystoneTeleportContext {
 
     void setPlaysEffect(boolean playsEffect);
 
-    default Predicate<? super ItemStack> getConsumeItemPredicate() {
-        return stack -> getWarpMode().consumesItem();
+    default boolean isWarpItemConsumed() {
+        return getWarpMode() != null && getWarpMode().consumesItem();
     };
 
-    default void setConsumeItemPredicate(Predicate<? super ItemStack> predicate) { }
+    default void setWarpItemConsumed(boolean isWarpItemConsumed) { }
 
-    default BiPredicate<? super Entity, ? super IWaystone> getAllowTeleportPredicate() {
-        return getWarpMode().getAllowTeleportPredicate();
-    }
-
-    default void setAllowTeleportPredicate(BiPredicate<? super Entity, ? super IWaystone> allowTeleportPredicate) { }
 }

--- a/shared/src/main/java/net/blay09/mods/waystones/core/PlayerWaystoneManager.java
+++ b/shared/src/main/java/net/blay09/mods/waystones/core/PlayerWaystoneManager.java
@@ -230,7 +230,7 @@ public class PlayerWaystoneManager {
             return Either.right(new WaystoneTeleportError.WarpModeRejected());
         }
 
-        if (!context.getAllowTeleportPredicate().test(entity, waystone)) {
+        if (!warpMode.getAllowTeleportPredicate().test(entity, waystone)) {
             return Either.right(new WaystoneTeleportError.WarpModeRejected());
         }
 
@@ -258,8 +258,7 @@ public class PlayerWaystoneManager {
         }
 
         boolean isCreativeMode = entity instanceof Player && ((Player) entity).getAbilities().instabuild;
-        if (!context.getWarpItem().isEmpty() && event.getConsumeItemResult().withDefault(() -> !isCreativeMode
-                && context.getConsumeItemPredicate().test(context.getWarpItem()))) {
+        if (!context.getWarpItem().isEmpty() && event.getConsumeItemResult().withDefault(() -> !isCreativeMode && context.isWarpItemConsumed())) {
             context.getWarpItem().shrink(1);
         }
 

--- a/shared/src/main/java/net/blay09/mods/waystones/core/PlayerWaystoneManager.java
+++ b/shared/src/main/java/net/blay09/mods/waystones/core/PlayerWaystoneManager.java
@@ -258,7 +258,7 @@ public class PlayerWaystoneManager {
         }
 
         boolean isCreativeMode = entity instanceof Player && ((Player) entity).getAbilities().instabuild;
-        if (!context.getWarpItem().isEmpty() && event.getConsumeItemResult().withDefault(() -> !isCreativeMode && context.isWarpItemConsumed())) {
+        if (!context.getWarpItem().isEmpty() && event.getConsumeItemResult().withDefault(() -> !isCreativeMode && context.consumesWarpItem())) {
             context.getWarpItem().shrink(1);
         }
 

--- a/shared/src/main/java/net/blay09/mods/waystones/core/PlayerWaystoneManager.java
+++ b/shared/src/main/java/net/blay09/mods/waystones/core/PlayerWaystoneManager.java
@@ -230,7 +230,7 @@ public class PlayerWaystoneManager {
             return Either.right(new WaystoneTeleportError.WarpModeRejected());
         }
 
-        if (!warpMode.getAllowTeleportPredicate().test(entity, waystone)) {
+        if (!context.getAllowTeleportPredicate().test(entity, waystone)) {
             return Either.right(new WaystoneTeleportError.WarpModeRejected());
         }
 
@@ -258,7 +258,8 @@ public class PlayerWaystoneManager {
         }
 
         boolean isCreativeMode = entity instanceof Player && ((Player) entity).getAbilities().instabuild;
-        if (!context.getWarpItem().isEmpty() && event.getConsumeItemResult().withDefault(() -> warpMode.consumesItem() && !isCreativeMode)) {
+        if (!context.getWarpItem().isEmpty() && event.getConsumeItemResult().withDefault(() -> !isCreativeMode
+                && context.getConsumeItemPredicate().test(context.getWarpItem()))) {
             context.getWarpItem().shrink(1);
         }
 

--- a/shared/src/main/java/net/blay09/mods/waystones/core/WaystoneTeleportContext.java
+++ b/shared/src/main/java/net/blay09/mods/waystones/core/WaystoneTeleportContext.java
@@ -24,7 +24,7 @@ public class WaystoneTeleportContext implements IWaystoneTeleportContext {
     private WarpMode warpMode = WarpMode.CUSTOM;
     private ItemStack warpItem = ItemStack.EMPTY;
     @Nullable
-    private Boolean isWarpItemConsumed;
+    private Boolean consumesWarpItem; // nullable for now so we can fallback to legacy warp mode implementation
     private int xpCost;
     private int cooldown;
     private boolean playsSound = true;
@@ -148,12 +148,12 @@ public class WaystoneTeleportContext implements IWaystoneTeleportContext {
     }
 
     @Override
-    public boolean isWarpItemConsumed() {
-        return this.isWarpItemConsumed == null ? getWarpMode().consumesItem() : this.isWarpItemConsumed;
+    public boolean consumesWarpItem() {
+        return this.consumesWarpItem == null ? getWarpMode().consumesItem() : this.consumesWarpItem;
     }
 
     @Override
-    public void setWarpItemConsumed(boolean isWarpItemConsumed) {
-        this.isWarpItemConsumed = isWarpItemConsumed;
+    public void setConsumesWarpItem(boolean consumesWarpItem) {
+        this.consumesWarpItem = consumesWarpItem;
     }
 }

--- a/shared/src/main/java/net/blay09/mods/waystones/core/WaystoneTeleportContext.java
+++ b/shared/src/main/java/net/blay09/mods/waystones/core/WaystoneTeleportContext.java
@@ -10,8 +10,6 @@ import org.jetbrains.annotations.Nullable;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.function.BiPredicate;
-import java.util.function.Predicate;
 
 public class WaystoneTeleportContext implements IWaystoneTeleportContext {
     private final Entity entity;
@@ -25,12 +23,12 @@ public class WaystoneTeleportContext implements IWaystoneTeleportContext {
 
     private WarpMode warpMode = WarpMode.CUSTOM;
     private ItemStack warpItem;
+    @Nullable
+    private Boolean isWarpItemConsumed;
     private int xpCost;
     private int cooldown;
     private boolean playsSound = true;
     private boolean playsEffect = true;
-    private Predicate<? super ItemStack> consumeItemPredicate;
-    private BiPredicate<? super Entity, ? super IWaystone> allowTeleportPredicate;
 
     public WaystoneTeleportContext(Entity entity, IWaystone targetWaystone, TeleportDestination destination) {
         this.entity = entity;
@@ -150,22 +148,12 @@ public class WaystoneTeleportContext implements IWaystoneTeleportContext {
     }
 
     @Override
-    public Predicate<? super ItemStack> getConsumeItemPredicate() {
-        return this.consumeItemPredicate == null ? stack -> getWarpMode().consumesItem() : this.consumeItemPredicate;
+    public boolean isWarpItemConsumed() {
+        return this.isWarpItemConsumed == null ? getWarpMode().consumesItem() : this.isWarpItemConsumed;
     }
 
     @Override
-    public void setConsumeItemPredicate(Predicate<? super ItemStack> predicate) {
-        this.consumeItemPredicate = predicate;
-    }
-
-    @Override
-    public BiPredicate<? super Entity, ? super IWaystone> getAllowTeleportPredicate() {
-        return this.allowTeleportPredicate == null ? getWarpMode().getAllowTeleportPredicate() : this.allowTeleportPredicate;
-    }
-
-    @Override
-    public void setAllowTeleportPredicate(BiPredicate<? super Entity, ? super IWaystone> allowTeleportPredicate) {
-        this.allowTeleportPredicate = allowTeleportPredicate;
+    public void setWarpItemConsumed(boolean isWarpItemConsumed) {
+        this.isWarpItemConsumed = isWarpItemConsumed;
     }
 }

--- a/shared/src/main/java/net/blay09/mods/waystones/core/WaystoneTeleportContext.java
+++ b/shared/src/main/java/net/blay09/mods/waystones/core/WaystoneTeleportContext.java
@@ -3,7 +3,6 @@ package net.blay09.mods.waystones.core;
 import net.blay09.mods.waystones.api.IWaystone;
 import net.blay09.mods.waystones.api.IWaystoneTeleportContext;
 import net.blay09.mods.waystones.api.TeleportDestination;
-import net.minecraft.server.level.ServerLevel;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.Mob;
 import net.minecraft.world.item.ItemStack;
@@ -11,6 +10,8 @@ import org.jetbrains.annotations.Nullable;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.function.BiPredicate;
+import java.util.function.Predicate;
 
 public class WaystoneTeleportContext implements IWaystoneTeleportContext {
     private final Entity entity;
@@ -28,6 +29,8 @@ public class WaystoneTeleportContext implements IWaystoneTeleportContext {
     private int cooldown;
     private boolean playsSound = true;
     private boolean playsEffect = true;
+    private Predicate<? super ItemStack> consumeItemPredicate;
+    private BiPredicate<? super Entity, ? super IWaystone> allowTeleportPredicate;
 
     public WaystoneTeleportContext(Entity entity, IWaystone targetWaystone, TeleportDestination destination) {
         this.entity = entity;
@@ -144,5 +147,25 @@ public class WaystoneTeleportContext implements IWaystoneTeleportContext {
     @Override
     public void setPlaysEffect(boolean playsEffect) {
         this.playsEffect = playsEffect;
+    }
+
+    @Override
+    public Predicate<? super ItemStack> getConsumeItemPredicate() {
+        return this.consumeItemPredicate == null ? stack -> getWarpMode().consumesItem() : this.consumeItemPredicate;
+    }
+
+    @Override
+    public void setConsumeItemPredicate(Predicate<? super ItemStack> predicate) {
+        this.consumeItemPredicate = predicate;
+    }
+
+    @Override
+    public BiPredicate<? super Entity, ? super IWaystone> getAllowTeleportPredicate() {
+        return this.allowTeleportPredicate == null ? getWarpMode().getAllowTeleportPredicate() : this.allowTeleportPredicate;
+    }
+
+    @Override
+    public void setAllowTeleportPredicate(BiPredicate<? super Entity, ? super IWaystone> allowTeleportPredicate) {
+        this.allowTeleportPredicate = allowTeleportPredicate;
     }
 }


### PR DESCRIPTION
This commit further prepares the phasing out of WarpMode by transferring some responsibilities to IWaystoneTeleportContext:
 - getConsumesPredicate to decide if a warp item ItemStack should be consumed
 - getAllowTeleportPredicate to decide if the teleport event is possible at all

The PlayerWaystoneManager now uses these IWaystoneTeleportContext methods rather than WarpMode equivalents. Note that for backwards compatibility there is a default implementation which simply delegates to the WarpMode methods.