### PR TITLE
[1.21.4] Lithostitched compat

### DIFF
--- a/common/src/main/java/net/blay09/mods/waystones/worldgen/ModWorldGen.java
+++ b/common/src/main/java/net/blay09/mods/waystones/worldgen/ModWorldGen.java
@@ -6,6 +6,7 @@ import net.blay09.mods.balm.api.Balm;
 import net.blay09.mods.balm.api.DeferredObject;
 import net.blay09.mods.balm.api.event.server.ServerReloadedEvent;
 import net.blay09.mods.balm.api.event.server.ServerStartedEvent;
+import net.blay09.mods.balm.api.event.server.ServerStartingEvent;
 import net.blay09.mods.balm.api.world.BalmWorldGen;
 import net.blay09.mods.balm.api.world.BiomePredicate;
 import net.blay09.mods.waystones.Waystones;
@@ -83,8 +84,7 @@ public class ModWorldGen {
         worldGen.registerPoiType(id("wild_waystone"), () -> new PoiType(gatherWaystonesOfOrigin(WaystoneOrigin.WILDERNESS), 1, 1));
         worldGen.registerPoiType(id("village_waystone"), () -> new PoiType(gatherWaystonesOfOrigin(WaystoneOrigin.VILLAGE), 1, 1));
 
-        Balm.getEvents().onEvent(ServerStartedEvent.class, event -> setupDynamicRegistries(event.getServer().registryAccess()));
-        Balm.getEvents().onEvent(ServerReloadedEvent.class, event -> setupDynamicRegistries(event.getServer().registryAccess()));
+        Balm.getEvents().onEvent(ServerStartingEvent.class, event -> setupDynamicRegistries(event.getServer().registryAccess()));
     }
 
     private static Set<BlockState> gatherWaystonesOfOrigin(WaystoneOrigin origin) {

--- a/common/src/main/resources/data/waystones/lithostitched/worldgen_modifier/guaranteed_waystone_desert.json
+++ b/common/src/main/resources/data/waystones/lithostitched/worldgen_modifier/guaranteed_waystone_desert.json
@@ -1,0 +1,29 @@
+{
+  "fabric:load_conditions": [
+    {
+      "condition": "waystones:force"
+    }
+  ],
+  "neoforge:conditions": [
+    {
+      "type": "waystones:force"
+    }
+  ],
+  "type": "lithostitched:add_template_pool_elements",
+  "template_pools": "minecraft:village/desert/houses",
+  "elements": [
+    {
+      "weight": 1,
+      "element": {
+        "element_type": "lithostitched:delegating",
+        "delegate": {
+          "element_type": "minecraft:legacy_single_pool_element",
+          "projection": "rigid",
+          "location": "waystones:village/desert/waystone",
+          "processors": "minecraft:empty"
+        },
+        "forced_count": 1
+      }
+    }
+  ]
+}

--- a/common/src/main/resources/data/waystones/lithostitched/worldgen_modifier/guaranteed_waystone_plains.json
+++ b/common/src/main/resources/data/waystones/lithostitched/worldgen_modifier/guaranteed_waystone_plains.json
@@ -1,0 +1,29 @@
+{
+  "fabric:load_conditions": [
+    {
+      "condition": "waystones:force"
+    }
+  ],
+  "neoforge:conditions": [
+    {
+      "type": "waystones:force"
+    }
+  ],
+  "type": "lithostitched:add_template_pool_elements",
+  "template_pools": "minecraft:village/plains/houses",
+  "elements": [
+    {
+      "weight": 1,
+      "element": {
+        "element_type": "lithostitched:delegating",
+        "delegate": {
+          "element_type": "minecraft:legacy_single_pool_element",
+          "projection": "rigid",
+          "location": "waystones:village/common/waystone",
+          "processors": "minecraft:empty"
+        },
+        "forced_count": 1
+      }
+    }
+  ]
+}

--- a/common/src/main/resources/data/waystones/lithostitched/worldgen_modifier/guaranteed_waystone_savanna.json
+++ b/common/src/main/resources/data/waystones/lithostitched/worldgen_modifier/guaranteed_waystone_savanna.json
@@ -1,0 +1,29 @@
+{
+  "fabric:load_conditions": [
+    {
+      "condition": "waystones:force"
+    }
+  ],
+  "neoforge:conditions": [
+    {
+      "type": "waystones:force"
+    }
+  ],
+  "type": "lithostitched:add_template_pool_elements",
+  "template_pools": "minecraft:village/savanna/houses",
+  "elements": [
+    {
+      "weight": 1,
+      "element": {
+        "element_type": "lithostitched:delegating",
+        "delegate": {
+          "element_type": "minecraft:legacy_single_pool_element",
+          "projection": "rigid",
+          "location": "waystones:village/common/waystone",
+          "processors": "minecraft:empty"
+        },
+        "forced_count": 1
+      }
+    }
+  ]
+}

--- a/common/src/main/resources/data/waystones/lithostitched/worldgen_modifier/guaranteed_waystone_snowy.json
+++ b/common/src/main/resources/data/waystones/lithostitched/worldgen_modifier/guaranteed_waystone_snowy.json
@@ -1,0 +1,29 @@
+{
+  "fabric:load_conditions": [
+    {
+      "condition": "waystones:force"
+    }
+  ],
+  "neoforge:conditions": [
+    {
+      "type": "waystones:force"
+    }
+  ],
+  "type": "lithostitched:add_template_pool_elements",
+  "template_pools": "minecraft:village/snowy/houses",
+  "elements": [
+    {
+      "weight": 1,
+      "element": {
+        "element_type": "lithostitched:delegating",
+        "delegate": {
+          "element_type": "minecraft:legacy_single_pool_element",
+          "projection": "rigid",
+          "location": "waystones:village/common/waystone",
+          "processors": "minecraft:empty"
+        },
+        "forced_count": 1
+      }
+    }
+  ]
+}

--- a/common/src/main/resources/data/waystones/lithostitched/worldgen_modifier/guaranteed_waystone_taiga.json
+++ b/common/src/main/resources/data/waystones/lithostitched/worldgen_modifier/guaranteed_waystone_taiga.json
@@ -1,0 +1,29 @@
+{
+  "fabric:load_conditions": [
+    {
+      "condition": "waystones:force"
+    }
+  ],
+  "neoforge:conditions": [
+    {
+      "type": "waystones:force"
+    }
+  ],
+  "type": "lithostitched:add_template_pool_elements",
+  "template_pools": "minecraft:village/taiga/houses",
+  "elements": [
+    {
+      "weight": 1,
+      "element": {
+        "element_type": "lithostitched:delegating",
+        "delegate": {
+          "element_type": "minecraft:legacy_single_pool_element",
+          "projection": "rigid",
+          "location": "waystones:village/common/waystone",
+          "processors": "minecraft:empty"
+        },
+        "forced_count": 1
+      }
+    }
+  ]
+}

--- a/fabric/src/main/java/net/blay09/mods/waystones/compat/lithostitched/ForceWaystoneCondition.java
+++ b/fabric/src/main/java/net/blay09/mods/waystones/compat/lithostitched/ForceWaystoneCondition.java
@@ -1,0 +1,31 @@
+package net.blay09.mods.waystones.compat.lithostitched;
+
+import com.mojang.serialization.MapCodec;
+import net.blay09.mods.waystones.Waystones;
+import net.blay09.mods.waystones.config.WaystonesConfig;
+import net.blay09.mods.waystones.config.WaystonesConfigData;
+import net.fabricmc.fabric.api.resource.conditions.v1.ResourceCondition;
+import net.fabricmc.fabric.api.resource.conditions.v1.ResourceConditionType;
+import net.fabricmc.fabric.api.resource.conditions.v1.ResourceConditions;
+import net.minecraft.resources.RegistryOps;
+import net.minecraft.resources.ResourceLocation;
+import org.jetbrains.annotations.Nullable;
+
+public class ForceWaystoneCondition implements ResourceCondition {
+    public static final MapCodec<ForceWaystoneCondition> CODEC = MapCodec.unit(ForceWaystoneCondition::new);
+    public static final ResourceConditionType<ForceWaystoneCondition> TYPE = ResourceConditionType.create(ResourceLocation.fromNamespaceAndPath(Waystones.MOD_ID, "force"), CODEC);
+
+    @Override
+    public ResourceConditionType<?> getType() {
+        return TYPE;
+    }
+
+    @Override
+    public boolean test(@Nullable RegistryOps.RegistryInfoLookup registryInfoLookup) {
+        return WaystonesConfig.getActive().worldGen.spawnInVillages == WaystonesConfigData.VillageWaystoneGeneration.FREQUENT;
+    }
+
+    public static void initialize() {
+        ResourceConditions.register(TYPE);
+    }
+}

--- a/fabric/src/main/java/net/blay09/mods/waystones/fabric/FabricWaystones.java
+++ b/fabric/src/main/java/net/blay09/mods/waystones/fabric/FabricWaystones.java
@@ -3,6 +3,7 @@ package net.blay09.mods.waystones.fabric;
 import net.blay09.mods.balm.api.Balm;
 import net.blay09.mods.balm.api.EmptyLoadContext;
 import net.blay09.mods.waystones.Waystones;
+import net.blay09.mods.waystones.compat.lithostitched.ForceWaystoneCondition;
 import net.fabricmc.api.ModInitializer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -24,6 +25,10 @@ public class FabricWaystones implements ModInitializer {
             } catch (InstantiationException | IllegalAccessException | NoSuchMethodException | ClassNotFoundException | InvocationTargetException e) {
                 logger.error("Failed to load Repurposed Structures integration", e);
             }
+        }
+
+        if (Balm.isModLoaded("lithostitched")) {
+            ForceWaystoneCondition.initialize();
         }
     }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -33,8 +33,8 @@ pack_format_number = 18
 java_version = 21
 
 # Balm
-balm_version = 21.4.7-SNAPSHOT
-balm_version_range = [21.4.0,)
+balm_version = 21.4.22-SNAPSHOT
+balm_version_range = [21.4.22,)
 
 # Forge
 forge_version = 54.0.16

--- a/neoforge/src/main/java/net/blay09/mods/waystones/NeoForgeWaystones.java
+++ b/neoforge/src/main/java/net/blay09/mods/waystones/NeoForgeWaystones.java
@@ -3,6 +3,7 @@ package net.blay09.mods.waystones;
 import net.blay09.mods.balm.api.Balm;
 import net.blay09.mods.balm.neoforge.NeoForgeLoadContext;
 import net.blay09.mods.waystones.compat.Compat;
+import net.blay09.mods.waystones.compat.lithostitched.ForceWaystoneCondition;
 import net.neoforged.bus.api.IEventBus;
 import net.neoforged.fml.common.Mod;
 import org.slf4j.Logger;
@@ -28,6 +29,10 @@ public class NeoForgeWaystones {
             } catch (InstantiationException | IllegalAccessException | NoSuchMethodException | ClassNotFoundException | InvocationTargetException e) {
                 logger.error("Failed to load Repurposed Structures integration", e);
             }
+        }
+
+        if (Balm.isModLoaded("lithostitched")) {
+            ForceWaystoneCondition.initialize();
         }
     }
 }

--- a/neoforge/src/main/java/net/blay09/mods/waystones/compat/lithostitched/ForceWaystoneCondition.java
+++ b/neoforge/src/main/java/net/blay09/mods/waystones/compat/lithostitched/ForceWaystoneCondition.java
@@ -1,0 +1,31 @@
+package net.blay09.mods.waystones.compat.lithostitched;
+
+import com.mojang.serialization.MapCodec;
+import net.blay09.mods.waystones.Waystones;
+import net.blay09.mods.waystones.config.WaystonesConfig;
+import net.blay09.mods.waystones.config.WaystonesConfigData;
+import net.neoforged.neoforge.common.conditions.ICondition;
+import net.neoforged.neoforge.registries.DeferredHolder;
+import net.neoforged.neoforge.registries.DeferredRegister;
+import net.neoforged.neoforge.registries.NeoForgeRegistries;
+
+public class ForceWaystoneCondition implements ICondition {
+    public static final DeferredRegister<MapCodec<? extends ICondition>> CONDITION_TYPES = DeferredRegister.create(NeoForgeRegistries.Keys.CONDITION_CODECS, Waystones.MOD_ID);
+    public static final DeferredHolder<MapCodec<? extends ICondition>, MapCodec<ForceWaystoneCondition>> FORCE_WAYSTONE = CONDITION_TYPES.register("force", () -> ForceWaystoneCondition.CODEC);
+
+    public static final MapCodec<ForceWaystoneCondition> CODEC = MapCodec.unit(ForceWaystoneCondition::new);
+
+    @Override
+    public boolean test(IContext iContext) {
+        return WaystonesConfig.getActive().worldGen.spawnInVillages == WaystonesConfigData.VillageWaystoneGeneration.FREQUENT;
+    }
+
+    @Override
+    public MapCodec<? extends ICondition> codec() {
+        return CODEC;
+    }
+
+    public static void initialize() {
+
+    }
+}


### PR DESCRIPTION
Makes two changes to have full compatibility with Lithostitched.

1. The normal waystone injection is ran too late. It has been moved to targeting the `ServerStartingEvent` instead of the `ServerStartedEvent`.
2. The forced waystone injection targets vanilla jigsaw code. This is fixed with a few Lithostitched worldgen modifiers injecting guaranteed pool elements into vanilla villages. Resource conditions are registered on Fabric and Neoforge to apply these only when the config says they should.

1.21.1/1.20.1 backports of this fix will happen soon.