### PR TITLE
1.21.1 Add server-controlled Sharestone coordinate privacy (invites + client sync) and make JourneyMap respect it

### DIFF
--- a/common/src/main/java/net/blay09/mods/waystones/block/entity/SharestoneBlockEntity.java
+++ b/common/src/main/java/net/blay09/mods/waystones/block/entity/SharestoneBlockEntity.java
@@ -3,8 +3,11 @@ package net.blay09.mods.waystones.block.entity;
 import net.blay09.mods.balm.api.menu.BalmMenuProvider;
 import net.blay09.mods.waystones.api.WaystoneOrigin;
 import net.blay09.mods.waystones.block.SharestoneBlock;
-import net.blay09.mods.waystones.core.*;
+import net.blay09.mods.waystones.core.PlayerWaystoneManager;
+import net.blay09.mods.waystones.core.WaystoneBlockEntityBase;
+import net.blay09.mods.waystones.core.WaystoneSyncManager;
 import net.blay09.mods.waystones.api.WaystoneTypes;
+import net.blay09.mods.waystones.config.WaystonesConfig;
 import net.blay09.mods.waystones.menu.ModMenus;
 import net.blay09.mods.waystones.menu.WaystoneSelectionMenu;
 import net.minecraft.core.BlockPos;
@@ -24,9 +27,6 @@ import org.jetbrains.annotations.Nullable;
 
 import java.util.Collections;
 import java.util.Optional;
-import java.util.Comparator;
-import java.util.List;
-import java.util.stream.Collectors;
 
 public class SharestoneBlockEntity extends WaystoneBlockEntityBase {
 
@@ -70,7 +70,11 @@ public class SharestoneBlockEntity extends WaystoneBlockEntityBase {
 
             @Override
             public WaystoneSelectionMenu.Data getScreenOpeningData(ServerPlayer serverPlayer) {
-                return new WaystoneSelectionMenu.Data(getWaystone(), PlayerWaystoneManager.getTargetsForWaystone(serverPlayer, getWaystone()));
+                if (WaystonesConfig.getActive().compatibility.sharestonesSendCoordsToClients) {
+                    return WaystoneSelectionMenu.Data.forWaystones(getWaystone(), PlayerWaystoneManager.getTargetsForWaystone(serverPlayer, getWaystone()));
+                }
+                return WaystoneSelectionMenu.Data.forRestrictedEntries(getWaystone(),
+                        PlayerWaystoneManager.getSharestoneSelectionEntries(serverPlayer, getWaystone()));
             }
 
             @Override

--- a/common/src/main/java/net/blay09/mods/waystones/block/entity/WaystoneBlockEntity.java
+++ b/common/src/main/java/net/blay09/mods/waystones/block/entity/WaystoneBlockEntity.java
@@ -53,7 +53,7 @@ public class WaystoneBlockEntity extends WaystoneBlockEntityBase {
 
             @Override
             public WaystoneSelectionMenu.Data getScreenOpeningData(ServerPlayer serverPlayer) {
-                return new WaystoneSelectionMenu.Data(getWaystone(), PlayerWaystoneManager.getTargetsForWaystone(serverPlayer, getWaystone()));
+                return WaystoneSelectionMenu.Data.forWaystones(getWaystone(), PlayerWaystoneManager.getTargetsForWaystone(serverPlayer, getWaystone()));
             }
 
             @Override

--- a/common/src/main/java/net/blay09/mods/waystones/client/gui/screen/WaystoneSelectionScreenBase.java
+++ b/common/src/main/java/net/blay09/mods/waystones/client/gui/screen/WaystoneSelectionScreenBase.java
@@ -9,6 +9,7 @@ import net.blay09.mods.waystones.client.gui.widget.RemoveWaystoneButton;
 import net.blay09.mods.waystones.client.gui.widget.SortWaystoneButton;
 import net.blay09.mods.waystones.client.gui.widget.WaystoneButton;
 import net.blay09.mods.waystones.comparator.UserSortingComparator;
+import net.blay09.mods.waystones.core.SharestoneSelectionEntry;
 import net.blay09.mods.waystones.requirement.NoRequirement;
 import net.blay09.mods.waystones.menu.WaystoneSelectionMenu;
 import net.blay09.mods.waystones.core.PlayerWaystoneManager;
@@ -37,12 +38,14 @@ import org.lwjgl.glfw.GLFW;
 
 import java.util.*;
 import java.util.function.Predicate;
+import java.util.stream.Collectors;
 
 public abstract class WaystoneSelectionScreenBase extends AbstractContainerScreen<WaystoneSelectionMenu> {
 
     private final Collection<Waystone> waystones;
     private List<Waystone> filteredWaystones;
     private final List<ITooltipProvider> tooltipProviders = new ArrayList<>();
+    private final Map<UUID, SharestoneSelectionEntry> restrictedEntriesById;
 
     private String searchText = "";
 
@@ -61,6 +64,12 @@ public abstract class WaystoneSelectionScreenBase extends AbstractContainerScree
     public WaystoneSelectionScreenBase(WaystoneSelectionMenu container, Inventory playerInventory, Component title) {
         super(container, playerInventory, title);
         waystones = container.getWaystones();
+        if (container.hasRestrictedEntries()) {
+            restrictedEntriesById = container.getRestrictedEntries().stream()
+                    .collect(Collectors.toMap(SharestoneSelectionEntry::id, entry -> entry));
+        } else {
+            restrictedEntriesById = Collections.emptyMap();
+        }
         PlayerWaystoneManager.ensureSortingIndex(Minecraft.getInstance().player, waystones);
         filteredWaystones = new ArrayList<>(waystones);
         final var sorting = getSorting();
@@ -206,7 +215,11 @@ public abstract class WaystoneSelectionScreenBase extends AbstractContainerScree
         final var player = Minecraft.getInstance().player;
         final var context = WaystonesAPI.createUnboundTeleportContext(player, waystone).setFromWaystone(waystoneFrom).setWarpItem(menu.getWarpItem()).addFlags(flags);
         final var requirements = WaystonesAPI.resolveRequirements(context);
-        WaystoneButton btnWaystone = new WaystoneButton(width / 2 - 100, y, waystone, requirements, button -> onWaystoneSelected(waystone));
+        final var entry = restrictedEntriesById.get(waystone.getWaystoneUid());
+        final Integer distanceOverride = entry != null ? entry.distanceMeters() : null;
+        WaystoneButton btnWaystone = new WaystoneButton(width / 2 - 100, y, waystone, requirements,
+                button -> onWaystoneSelected(entry != null ? entry.id() : waystone.getWaystoneUid()),
+                distanceOverride);
         if (waystoneFrom != null && waystone.getWaystoneUid().equals(waystoneFrom.getWaystoneUid())) {
             btnWaystone.active = false;
         }
@@ -214,7 +227,11 @@ public abstract class WaystoneSelectionScreenBase extends AbstractContainerScree
     }
 
     protected void onWaystoneSelected(Waystone waystone) {
-        Balm.getNetworking().sendToServer(new SelectWaystoneMessage(waystone.getWaystoneUid()));
+        onWaystoneSelected(waystone.getWaystoneUid());
+    }
+
+    protected void onWaystoneSelected(UUID waystoneId) {
+        Balm.getNetworking().sendToServer(new SelectWaystoneMessage(waystoneId));
     }
 
     private void sortWaystone(Waystone waystone, int sortDir) {

--- a/common/src/main/java/net/blay09/mods/waystones/client/gui/screen/WaystoneSelectionScreenBase.java
+++ b/common/src/main/java/net/blay09/mods/waystones/client/gui/screen/WaystoneSelectionScreenBase.java
@@ -66,7 +66,7 @@ public abstract class WaystoneSelectionScreenBase extends AbstractContainerScree
         waystones = container.getWaystones();
         if (container.hasRestrictedEntries()) {
             restrictedEntriesById = container.getRestrictedEntries().stream()
-                    .collect(Collectors.toMap(SharestoneSelectionEntry::id, entry -> entry));
+                    .collect(Collectors.toMap(SharestoneSelectionEntry::id, entry -> entry, (existing, duplicate) -> existing));
         } else {
             restrictedEntriesById = Collections.emptyMap();
         }

--- a/common/src/main/java/net/blay09/mods/waystones/client/gui/widget/WaystoneButton.java
+++ b/common/src/main/java/net/blay09/mods/waystones/client/gui/widget/WaystoneButton.java
@@ -6,6 +6,7 @@ import net.blay09.mods.waystones.api.WaystoneTypes;
 import net.blay09.mods.waystones.api.WaystoneVisibility;
 import net.blay09.mods.waystones.api.requirement.WarpRequirement;
 import net.blay09.mods.waystones.client.requirement.RequirementClientRegistry;
+import net.blay09.mods.waystones.core.RestrictedWaystone;
 import net.blay09.mods.waystones.core.WaystoneDistanceProvider;
 import net.minecraft.ChatFormatting;
 import net.minecraft.client.Minecraft;
@@ -60,7 +61,7 @@ public class WaystoneButton extends Button {
             Integer distance = null;
             if (waystone instanceof WaystoneDistanceProvider distanceProvider && distanceProvider.hasDistance()) {
                 distance = distanceProvider.getDistance();
-            } else if (waystone.getDimension() == player.level().dimension()) {
+            } else if (!(waystone instanceof RestrictedWaystone) && waystone.getDimension() == player.level().dimension()) {
                 distance = (int) player.position().distanceTo(waystone.getPos().getCenter());
             }
 

--- a/common/src/main/java/net/blay09/mods/waystones/client/gui/widget/WaystoneButton.java
+++ b/common/src/main/java/net/blay09/mods/waystones/client/gui/widget/WaystoneButton.java
@@ -24,12 +24,18 @@ public class WaystoneButton extends Button {
 
     private final WarpRequirement warpRequirement;
     private final Waystone waystone;
+    private final Integer distanceOverride;
 
     public WaystoneButton(int x, int y, Waystone waystone, WarpRequirement warpRequirement, OnPress pressable) {
+        this(x, y, waystone, warpRequirement, pressable, null);
+    }
+
+    public WaystoneButton(int x, int y, Waystone waystone, WarpRequirement warpRequirement, OnPress pressable, Integer distanceOverride) {
         super(x, y, 200, 20, getWaystoneNameComponent(waystone), pressable, Button.DEFAULT_NARRATION);
         Player player = Minecraft.getInstance().player;
         this.warpRequirement = warpRequirement;
         this.waystone = waystone;
+        this.distanceOverride = distanceOverride;
         if (player == null) {
             active = false;
         } else if (!warpRequirement.canAfford(player) && !player.getAbilities().instabuild) {
@@ -59,7 +65,9 @@ public class WaystoneButton extends Button {
         // render distance
         if (isActive()) {
             Integer distance = null;
-            if (waystone instanceof WaystoneDistanceProvider distanceProvider && distanceProvider.hasDistance()) {
+            if (distanceOverride != null && distanceOverride >= 0) {
+                distance = distanceOverride;
+            } else if (waystone instanceof WaystoneDistanceProvider distanceProvider && distanceProvider.hasDistance()) {
                 distance = distanceProvider.getDistance();
             } else if (!(waystone instanceof RestrictedWaystone) && waystone.getDimension() == player.level().dimension()) {
                 distance = (int) player.position().distanceTo(waystone.getPos().getCenter());

--- a/common/src/main/java/net/blay09/mods/waystones/client/gui/widget/WaystoneButton.java
+++ b/common/src/main/java/net/blay09/mods/waystones/client/gui/widget/WaystoneButton.java
@@ -6,6 +6,7 @@ import net.blay09.mods.waystones.api.WaystoneTypes;
 import net.blay09.mods.waystones.api.WaystoneVisibility;
 import net.blay09.mods.waystones.api.requirement.WarpRequirement;
 import net.blay09.mods.waystones.client.requirement.RequirementClientRegistry;
+import net.blay09.mods.waystones.core.WaystoneDistanceProvider;
 import net.minecraft.ChatFormatting;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.GuiGraphics;
@@ -55,17 +56,25 @@ public class WaystoneButton extends Button {
         final var player = Minecraft.getInstance().player;
 
         // render distance
-        if (waystone.getDimension() == player.level().dimension() && isActive()) {
-            int distance = (int) player.position().distanceTo(waystone.getPos().getCenter());
-            String distanceStr;
-            if (distance < 10000 && (font.width(getMessage()) < 120 || distance < 1000)) {
-                distanceStr = distance + "m";
-            } else {
-                // sorry for ugly code, chatgpt was down and this was the only thing my dumbed down brain could come up with
-                distanceStr = String.format("%.1f", distance / 1000f).replace(",0", "").replace(".0", "") + "km";
+        if (isActive()) {
+            Integer distance = null;
+            if (waystone instanceof WaystoneDistanceProvider distanceProvider && distanceProvider.hasDistance()) {
+                distance = distanceProvider.getDistance();
+            } else if (waystone.getDimension() == player.level().dimension()) {
+                distance = (int) player.position().distanceTo(waystone.getPos().getCenter());
             }
-            int xOffset = getWidth() - font.width(distanceStr);
-            guiGraphics.drawString(font, distanceStr, getX() + xOffset - 4, getY() + 6, 0xFFFFFF);
+
+            if (distance != null) {
+                String distanceStr;
+                if (distance < 10000 && (font.width(getMessage()) < 120 || distance < 1000)) {
+                    distanceStr = distance + "m";
+                } else {
+                    // sorry for ugly code, chatgpt was down and this was the only thing my dumbed down brain could come up with
+                    distanceStr = String.format("%.1f", distance / 1000f).replace(",0", "").replace(".0", "") + "km";
+                }
+                int xOffset = getWidth() - font.width(distanceStr);
+                guiGraphics.drawString(font, distanceStr, getX() + xOffset - 4, getY() + 6, 0xFFFFFF);
+            }
         }
 
         renderRequirements(warpRequirement, guiGraphics, mouseX, mouseY, partialTicks);

--- a/common/src/main/java/net/blay09/mods/waystones/compat/JourneyMapIntegration.java
+++ b/common/src/main/java/net/blay09/mods/waystones/compat/JourneyMapIntegration.java
@@ -107,13 +107,17 @@ public class JourneyMapIntegration implements IClientPlugin {
     }
 
     public void onWaystonesListReceived(WaystonesListReceivedEvent event) {
-        if (shouldManageWaypoints() && isSupportedWaystoneType(event.getWaystoneType())) {
+        if (shouldManageWaypoints() && shouldProcessWaystoneType(event.getWaystoneType())) {
             runWhenJourneyMapIsReady(() -> updateAllWaypoints(event.getWaystoneType(), event.getWaystones()));
         }
     }
 
-    private boolean isSupportedWaystoneType(ResourceLocation waystoneType) {
-        return waystoneType.equals(WaystoneTypes.WAYSTONE) || WaystoneTypes.isSharestone(waystoneType);
+    private static boolean shouldProcessWaystoneType(ResourceLocation waystoneType) {
+        if (WaystoneTypes.isSharestone(waystoneType)) {
+            return WaystonesConfig.getActive().compatibility.sharestonesSendCoordsToClients;
+        }
+
+        return waystoneType.equals(WaystoneTypes.WAYSTONE);
     }
 
     private static boolean shouldManageWaypoints() {
@@ -126,13 +130,13 @@ public class JourneyMapIntegration implements IClientPlugin {
     }
 
     public void onWaystoneUpdateReceived(WaystoneUpdateReceivedEvent event) {
-        if (shouldManageWaypoints() && isSupportedWaystoneType(event.getWaystone().getWaystoneType())) {
+        if (shouldManageWaypoints() && shouldProcessWaystoneType(event.getWaystone().getWaystoneType())) {
             runWhenJourneyMapIsReady(() -> updateWaypoint(event.getWaystone()));
         }
     }
 
     public void onWaystoneRemoveReceived(WaystoneRemoveReceivedEvent event) {
-        if (shouldManageWaypoints() && isSupportedWaystoneType(event.getWaystoneType())) {
+        if (shouldManageWaypoints() && shouldProcessWaystoneType(event.getWaystoneType())) {
             runWhenJourneyMapIsReady(() -> removeWaypoint(event.getWaystoneId()));
         }
     }

--- a/common/src/main/java/net/blay09/mods/waystones/compat/JourneyMapIntegration.java
+++ b/common/src/main/java/net/blay09/mods/waystones/compat/JourneyMapIntegration.java
@@ -107,8 +107,15 @@ public class JourneyMapIntegration implements IClientPlugin {
     }
 
     public void onWaystonesListReceived(WaystonesListReceivedEvent event) {
-        if (shouldManageWaypoints() && shouldProcessWaystoneType(event.getWaystoneType())) {
+        if (!shouldManageWaypoints()) {
+            return;
+        }
+
+        if (shouldProcessWaystoneType(event.getWaystoneType())) {
             runWhenJourneyMapIsReady(() -> updateAllWaypoints(event.getWaystoneType(), event.getWaystones()));
+        } else if (WaystoneTypes.isSharestone(event.getWaystoneType())
+                && !WaystonesConfig.getActive().compatibility.sharestonesSendCoordsToClients) {
+            runWhenJourneyMapIsReady(() -> clearWaypointsForType(event.getWaystoneType()));
         }
     }
 
@@ -163,6 +170,18 @@ public class JourneyMapIntegration implements IClientPlugin {
                 if (waystoneType.equals(customData.waystoneType()) && !stillExistingIds.contains(waystoneUid)) {
                     api.removeWaypoint(Waystones.MOD_ID, waypoint);
                     waystoneToWaypoint.remove(waystoneUid);
+                }
+            });
+        }
+    }
+
+    private void clearWaypointsForType(ResourceLocation waystoneType) {
+        final var waypoints = api.getWaypoints(Waystones.MOD_ID);
+        for (final var waypoint : waypoints) {
+            WaystonesWaypointData.decode(waypoint.getCustomData()).ifPresent(customData -> {
+                if (waystoneType.equals(customData.waystoneType())) {
+                    api.removeWaypoint(Waystones.MOD_ID, waypoint);
+                    waystoneToWaypoint.remove(customData.waystoneId());
                 }
             });
         }

--- a/common/src/main/java/net/blay09/mods/waystones/config/WaystonesConfigData.java
+++ b/common/src/main/java/net/blay09/mods/waystones/config/WaystonesConfigData.java
@@ -161,6 +161,10 @@ public class WaystonesConfigData implements BalmConfigData {
 
         @Comment("If enabled, Waystones will add markers for waystones and sharestones to Dynmap.")
         public boolean dynmap = true;
+
+        @Synced
+        @Comment("If enabled, sharestone invites can include the sharestone's coordinates when sent to other players.")
+        public boolean sharestonesSendCoords = true;
     }
 
     public static class Client {

--- a/common/src/main/java/net/blay09/mods/waystones/config/WaystonesConfigData.java
+++ b/common/src/main/java/net/blay09/mods/waystones/config/WaystonesConfigData.java
@@ -165,6 +165,10 @@ public class WaystonesConfigData implements BalmConfigData {
         @Synced
         @Comment("If enabled, sharestone invites can include the sharestone's coordinates when sent to other players.")
         public boolean sharestonesSendCoords = true;
+
+        @Synced
+        @Comment("If enabled, clients receive sharestone coordinates when syncing sharestone lists.")
+        public boolean sharestonesSendCoordsToClients = true;
     }
 
     public static class Client {

--- a/common/src/main/java/net/blay09/mods/waystones/core/PlayerWaystoneManager.java
+++ b/common/src/main/java/net/blay09/mods/waystones/core/PlayerWaystoneManager.java
@@ -180,6 +180,13 @@ public class PlayerWaystoneManager {
         return result;
     }
 
+    public static List<SharestoneSelectionEntry> getSharestoneSelectionEntries(ServerPlayer player, Waystone waystone) {
+        final var targets = getTargetsForWaystone(player, waystone);
+        return targets.stream()
+                .map(target -> SharestoneSelectionEntry.fromWaystone(player, target))
+                .toList();
+    }
+
     public static Collection<Waystone> getTargetsForWaystoneType(Player player, ResourceLocation waystoneType) {
         final var result = new ArrayList<Waystone>();
         if (WaystoneTypes.isSharestone(waystoneType)) {

--- a/common/src/main/java/net/blay09/mods/waystones/core/RestrictedWaystone.java
+++ b/common/src/main/java/net/blay09/mods/waystones/core/RestrictedWaystone.java
@@ -1,0 +1,102 @@
+package net.blay09.mods.waystones.core;
+
+import net.blay09.mods.waystones.api.Waystone;
+import net.blay09.mods.waystones.api.WaystoneOrigin;
+import net.blay09.mods.waystones.api.WaystoneVisibility;
+import net.minecraft.core.BlockPos;
+import net.minecraft.network.chat.Component;
+import net.minecraft.resources.ResourceKey;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.level.Level;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.UUID;
+
+public class RestrictedWaystone implements Waystone, WaystoneDistanceProvider {
+
+    private final ResourceLocation waystoneType;
+    private final UUID waystoneUid;
+    private final WaystoneOrigin origin;
+    private final ResourceKey<Level> dimension;
+    private final Component name;
+    private final WaystoneVisibility visibility;
+    private final int distance;
+
+    public RestrictedWaystone(ResourceLocation waystoneType, UUID waystoneUid, WaystoneOrigin origin, ResourceKey<Level> dimension, Component name,
+                              WaystoneVisibility visibility, int distance) {
+        this.waystoneType = waystoneType;
+        this.waystoneUid = waystoneUid;
+        this.origin = origin;
+        this.dimension = dimension;
+        this.name = name;
+        this.visibility = visibility;
+        this.distance = distance;
+    }
+
+    @Override
+    public UUID getWaystoneUid() {
+        return waystoneUid;
+    }
+
+    @Override
+    public Component getName() {
+        return name;
+    }
+
+    @Override
+    public ResourceKey<Level> getDimension() {
+        return dimension;
+    }
+
+    @Override
+    public WaystoneOrigin getOrigin() {
+        return origin;
+    }
+
+    @Override
+    public boolean isOwner(Player player) {
+        return true;
+    }
+
+    @Override
+    public BlockPos getPos() {
+        return BlockPos.ZERO;
+    }
+
+    @Override
+    public boolean isValid() {
+        return true;
+    }
+
+    @Override
+    @Nullable
+    public UUID getOwnerUid() {
+        return null;
+    }
+
+    @Override
+    public ResourceLocation getWaystoneType() {
+        return waystoneType;
+    }
+
+    @Override
+    public boolean isTransient() {
+        return false;
+    }
+
+    @Override
+    public WaystoneVisibility getVisibility() {
+        return visibility;
+    }
+
+    @Override
+    public boolean hasDistance() {
+        return distance >= 0;
+    }
+
+    @Override
+    public int getDistance() {
+        return distance;
+    }
+}

--- a/common/src/main/java/net/blay09/mods/waystones/core/SharestoneSelectionEntry.java
+++ b/common/src/main/java/net/blay09/mods/waystones/core/SharestoneSelectionEntry.java
@@ -1,0 +1,63 @@
+package net.blay09.mods.waystones.core;
+
+import net.blay09.mods.waystones.api.Waystone;
+import net.blay09.mods.waystones.api.WaystoneOrigin;
+import net.blay09.mods.waystones.api.WaystoneVisibility;
+import net.minecraft.core.registries.Registries;
+import net.minecraft.network.RegistryFriendlyByteBuf;
+import net.minecraft.network.chat.Component;
+import net.minecraft.network.chat.ComponentSerialization;
+import net.minecraft.network.codec.ByteBufCodecs;
+import net.minecraft.network.codec.StreamCodec;
+import net.minecraft.resources.ResourceKey;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.world.level.Level;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+public record SharestoneSelectionEntry(UUID id, Component name, int distanceMeters, ResourceLocation waystoneType,
+                                       WaystoneVisibility visibility, WaystoneOrigin origin, ResourceKey<Level> dimension) {
+
+    public static final StreamCodec<RegistryFriendlyByteBuf, SharestoneSelectionEntry> STREAM_CODEC = StreamCodec.of(
+            SharestoneSelectionEntry::write,
+            SharestoneSelectionEntry::read);
+    public static final StreamCodec<RegistryFriendlyByteBuf, List<SharestoneSelectionEntry>> LIST_STREAM_CODEC = STREAM_CODEC.apply(
+            ByteBufCodecs.collection(ArrayList::new));
+
+    public static SharestoneSelectionEntry fromWaystone(ServerPlayer player, Waystone waystone) {
+        int distance = -1;
+        if (player.level().dimension().equals(waystone.getDimension())) {
+            distance = (int) player.position().distanceTo(waystone.getPos().getCenter());
+        }
+        return new SharestoneSelectionEntry(waystone.getWaystoneUid(), waystone.getName(), distance, waystone.getWaystoneType(),
+                waystone.getVisibility(), waystone.getOrigin(), waystone.getDimension());
+    }
+
+    public RestrictedWaystone toRestrictedWaystone() {
+        return new RestrictedWaystone(waystoneType, id, origin, dimension, name, visibility, distanceMeters);
+    }
+
+    private static void write(RegistryFriendlyByteBuf buf, SharestoneSelectionEntry entry) {
+        buf.writeUUID(entry.id());
+        ComponentSerialization.STREAM_CODEC.encode(buf, entry.name());
+        buf.writeInt(entry.distanceMeters());
+        buf.writeResourceLocation(entry.waystoneType());
+        buf.writeEnum(entry.visibility());
+        buf.writeEnum(entry.origin());
+        buf.writeResourceLocation(entry.dimension().location());
+    }
+
+    private static SharestoneSelectionEntry read(RegistryFriendlyByteBuf buf) {
+        final var id = buf.readUUID();
+        final var name = ComponentSerialization.STREAM_CODEC.decode(buf);
+        final var distance = buf.readInt();
+        final var waystoneType = buf.readResourceLocation();
+        final var visibility = buf.readEnum(WaystoneVisibility.class);
+        final var origin = buf.readEnum(WaystoneOrigin.class);
+        final var dimension = ResourceKey.create(Registries.DIMENSION, buf.readResourceLocation());
+        return new SharestoneSelectionEntry(id, name, distance, waystoneType, visibility, origin, dimension);
+    }
+}

--- a/common/src/main/java/net/blay09/mods/waystones/core/WaystoneDistanceProvider.java
+++ b/common/src/main/java/net/blay09/mods/waystones/core/WaystoneDistanceProvider.java
@@ -1,0 +1,7 @@
+package net.blay09.mods.waystones.core;
+
+public interface WaystoneDistanceProvider {
+    boolean hasDistance();
+
+    int getDistance();
+}

--- a/common/src/main/java/net/blay09/mods/waystones/core/WaystoneManagerImpl.java
+++ b/common/src/main/java/net/blay09/mods/waystones/core/WaystoneManagerImpl.java
@@ -42,10 +42,14 @@ public class WaystoneManagerImpl extends SavedData implements WaystoneManager {
     }
 
     public void updateWaystone(Waystone waystone) {
-        WaystoneImpl mutableWaystone = (WaystoneImpl) waystones.getOrDefault(waystone.getWaystoneUid(), waystone);
-        mutableWaystone.setName(waystone.getName());
-        mutableWaystone.setVisibility(waystone.getVisibility());
-        waystones.put(waystone.getWaystoneUid(), mutableWaystone);
+        Waystone existing = waystones.get(waystone.getWaystoneUid());
+        if (existing instanceof WaystoneImpl existingWaystone && waystone instanceof WaystoneImpl updatedWaystone) {
+            existingWaystone.setName(updatedWaystone.getName());
+            existingWaystone.setVisibility(updatedWaystone.getVisibility());
+            waystones.put(waystone.getWaystoneUid(), existingWaystone);
+        } else {
+            waystones.put(waystone.getWaystoneUid(), waystone);
+        }
         setDirty();
         Balm.getEvents().fireEvent(new WaystoneUpdatedEvent(waystone));
     }

--- a/common/src/main/java/net/blay09/mods/waystones/core/WaystoneSyncManager.java
+++ b/common/src/main/java/net/blay09/mods/waystones/core/WaystoneSyncManager.java
@@ -4,6 +4,7 @@ import net.blay09.mods.balm.api.Balm;
 import net.blay09.mods.waystones.api.Waystone;
 import net.blay09.mods.waystones.api.WaystoneCooldowns;
 import net.blay09.mods.waystones.api.WaystoneTypes;
+import net.blay09.mods.waystones.config.WaystonesConfig;
 import net.blay09.mods.waystones.network.message.*;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.server.MinecraftServer;
@@ -50,13 +51,30 @@ public class WaystoneSyncManager {
     }
 
     public static void sendWaystonesOfType(ResourceLocation waystoneType, ServerPlayer player) {
-        List<Waystone> warpPlates = WaystoneManagerImpl.get(player.server).getWaystonesByType(waystoneType).collect(Collectors.toList());
-        Balm.getNetworking().sendTo(player, new KnownWaystonesMessage(waystoneType, warpPlates));
+        if (WaystoneTypes.isSharestone(waystoneType)) {
+            sendSharestonesOfType(waystoneType, player);
+            return;
+        }
+        List<Waystone> waystones = WaystoneManagerImpl.get(player.server).getWaystonesByType(waystoneType).collect(Collectors.toList());
+        Balm.getNetworking().sendTo(player, new KnownWaystonesMessage(waystoneType, waystones));
     }
 
-    public static void sendWaystoneUpdate(Player player, Waystone waystone) {
+    public static void sendSharestonesOfType(ResourceLocation waystoneType, ServerPlayer player) {
+        List<Waystone> waystones = WaystoneManagerImpl.get(player.server).getWaystonesByType(waystoneType).collect(Collectors.toList());
+        if (!WaystonesConfig.getActive().compatibility.sharestonesSendCoordsToClients) {
+            Balm.getNetworking().sendTo(player, new RestrictedWaystonesMessage(waystoneType, buildSharestoneSyncData(player, waystones)));
+            return;
+        }
+        Balm.getNetworking().sendTo(player, new KnownWaystonesMessage(waystoneType, waystones));
+    }
+
+    public static void sendWaystoneUpdate(ServerPlayer player, Waystone waystone) {
         // If this is a waystone, only send an update if the player has activated it already
         if (!waystone.getWaystoneType().equals(WaystoneTypes.WAYSTONE) || PlayerWaystoneManager.isWaystoneActivated(player, waystone)) {
+            if (WaystoneTypes.isSharestone(waystone.getWaystoneType()) && !WaystonesConfig.getActive().compatibility.sharestonesSendCoordsToClients) {
+                Balm.getNetworking().sendTo(player, new UpdateRestrictedWaystoneMessage(SharestoneSyncData.fromWaystone(player, waystone)));
+                return;
+            }
             Balm.getNetworking().sendTo(player, new UpdateWaystoneMessage(waystone));
         }
     }
@@ -71,5 +89,11 @@ public class WaystoneSyncManager {
     public static void sendWaystoneCooldowns(Player player) {
         final var cooldowns = PlayerWaystoneManager.getCooldowns(player);
         Balm.getNetworking().sendTo(player, new PlayerWaystoneCooldownsMessage(cooldowns));
+    }
+
+    private static List<SharestoneSyncData> buildSharestoneSyncData(ServerPlayer player, List<Waystone> waystones) {
+        return waystones.stream()
+                .map(waystone -> SharestoneSyncData.fromWaystone(player, waystone))
+                .collect(Collectors.toList());
     }
 }

--- a/common/src/main/java/net/blay09/mods/waystones/handler/LoginHandler.java
+++ b/common/src/main/java/net/blay09/mods/waystones/handler/LoginHandler.java
@@ -27,7 +27,7 @@ public class LoginHandler {
         WaystoneSyncManager.sendActivatedWaystones(player);
         WaystoneSyncManager.sendWaystonesOfType(WaystoneTypes.WARP_PLATE, player);
         for (ResourceLocation dyedSharestone : WaystoneTypes.SHARESTONES) {
-            WaystoneSyncManager.sendWaystonesOfType(dyedSharestone, player);
+            WaystoneSyncManager.sendSharestonesOfType(dyedSharestone, player);
         }
         WaystoneSyncManager.sendWaystoneCooldowns(player);
     }

--- a/common/src/main/java/net/blay09/mods/waystones/menu/ModMenus.java
+++ b/common/src/main/java/net/blay09/mods/waystones/menu/ModMenus.java
@@ -40,7 +40,7 @@ public class ModMenus {
                     return new WaystoneSelectionMenu(ModMenus.waystoneSelection.get(),
                             data.fromWaystone(),
                             windowId,
-                            data.waystones(),
+                            data.resolveWaystones(),
                             Collections.emptySet());
                 }
 
@@ -118,7 +118,7 @@ public class ModMenus {
                     return new WaystoneSelectionMenu(ModMenus.sharestoneSelection.get(),
                             data.fromWaystone(),
                             windowId,
-                            data.waystones(),
+                            data.resolveWaystones(),
                             Collections.emptySet());
                 }
 

--- a/common/src/main/java/net/blay09/mods/waystones/menu/ModMenus.java
+++ b/common/src/main/java/net/blay09/mods/waystones/menu/ModMenus.java
@@ -119,7 +119,8 @@ public class ModMenus {
                             data.fromWaystone(),
                             windowId,
                             data.resolveWaystones(),
-                            Collections.emptySet());
+                            Collections.emptySet(),
+                            data.restrictedEntries());
                 }
 
                 @Override

--- a/common/src/main/java/net/blay09/mods/waystones/menu/WaystoneSelectionMenu.java
+++ b/common/src/main/java/net/blay09/mods/waystones/menu/WaystoneSelectionMenu.java
@@ -14,6 +14,7 @@ import net.minecraft.world.inventory.MenuType;
 import net.minecraft.world.item.ItemStack;
 import org.jetbrains.annotations.Nullable;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Set;
@@ -26,7 +27,7 @@ public class WaystoneSelectionMenu extends AbstractContainerMenu {
 
     public record Data(Waystone fromWaystone, List<Waystone> waystones, List<SharestoneSelectionEntry> restrictedEntries) {
         public static Data forWaystones(Waystone fromWaystone, Collection<Waystone> waystones) {
-            return new Data(fromWaystone, List.copyOf(waystones), Collections.emptyList());
+            return new Data(fromWaystone, new ArrayList<>(waystones), Collections.emptyList());
         }
 
         public static Data forRestrictedEntries(Waystone fromWaystone, Collection<SharestoneSelectionEntry> restrictedEntries) {

--- a/common/src/main/java/net/blay09/mods/waystones/menu/WaystoneSelectionMenu.java
+++ b/common/src/main/java/net/blay09/mods/waystones/menu/WaystoneSelectionMenu.java
@@ -2,6 +2,7 @@ package net.blay09.mods.waystones.menu;
 
 import net.blay09.mods.waystones.api.Waystone;
 import net.blay09.mods.waystones.api.WaystoneTeleportContext;
+import net.blay09.mods.waystones.core.SharestoneSelectionEntry;
 import net.blay09.mods.waystones.core.WaystoneImpl;
 import net.minecraft.core.BlockPos;
 import net.minecraft.network.RegistryFriendlyByteBuf;
@@ -14,6 +15,7 @@ import net.minecraft.world.item.ItemStack;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Set;
 import java.util.function.Consumer;
 import java.util.Comparator;
@@ -22,15 +24,32 @@ import java.util.stream.Collectors;
 
 public class WaystoneSelectionMenu extends AbstractContainerMenu {
 
-    public record Data(Waystone fromWaystone, Collection<Waystone> waystones) {
+    public record Data(Waystone fromWaystone, List<Waystone> waystones, List<SharestoneSelectionEntry> restrictedEntries) {
+        public static Data forWaystones(Waystone fromWaystone, Collection<Waystone> waystones) {
+            return new Data(fromWaystone, List.copyOf(waystones), Collections.emptyList());
+        }
+
+        public static Data forRestrictedEntries(Waystone fromWaystone, Collection<SharestoneSelectionEntry> restrictedEntries) {
+            return new Data(fromWaystone, Collections.emptyList(), List.copyOf(restrictedEntries));
+        }
+
+        public boolean hasRestrictedEntries() {
+            return !restrictedEntries.isEmpty();
+        }
+
+        public Collection<Waystone> resolveWaystones() {
+            if (hasRestrictedEntries()) {
+                return restrictedEntries.stream()
+                        .map(SharestoneSelectionEntry::toRestrictedWaystone)
+                        .collect(Collectors.toList());
+            }
+            return waystones;
+        }
     }
 
-    public static final StreamCodec<RegistryFriendlyByteBuf, Data> STREAM_CODEC = StreamCodec.composite(
-            WaystoneImpl.STREAM_CODEC,
-            Data::fromWaystone,
-            WaystoneImpl.LIST_STREAM_CODEC,
-            Data::waystones,
-            Data::new);
+    public static final StreamCodec<RegistryFriendlyByteBuf, Data> STREAM_CODEC = StreamCodec.of(
+            WaystoneSelectionMenu::writeData,
+            WaystoneSelectionMenu::readData);
 
     private final Waystone fromWaystone;
     private final Collection<Waystone> waystones;
@@ -89,5 +108,25 @@ public class WaystoneSelectionMenu extends AbstractContainerMenu {
     public WaystoneSelectionMenu setPostTeleportHandler(Consumer<WaystoneTeleportContext> postTeleportHandler) {
         this.postTeleportHandler = postTeleportHandler;
         return this;
+    }
+
+    private static void writeData(RegistryFriendlyByteBuf buf, Data data) {
+        WaystoneImpl.STREAM_CODEC.encode(buf, data.fromWaystone());
+        buf.writeBoolean(data.hasRestrictedEntries());
+        if (data.hasRestrictedEntries()) {
+            SharestoneSelectionEntry.LIST_STREAM_CODEC.encode(buf, data.restrictedEntries());
+        } else {
+            WaystoneImpl.LIST_STREAM_CODEC.encode(buf, data.waystones());
+        }
+    }
+
+    private static Data readData(RegistryFriendlyByteBuf buf) {
+        final var fromWaystone = WaystoneImpl.STREAM_CODEC.decode(buf);
+        if (buf.readBoolean()) {
+            final var entries = SharestoneSelectionEntry.LIST_STREAM_CODEC.decode(buf);
+            return Data.forRestrictedEntries(fromWaystone, entries);
+        }
+        final var waystones = WaystoneImpl.LIST_STREAM_CODEC.decode(buf);
+        return Data.forWaystones(fromWaystone, waystones);
     }
 }

--- a/common/src/main/java/net/blay09/mods/waystones/menu/WaystoneSelectionMenu.java
+++ b/common/src/main/java/net/blay09/mods/waystones/menu/WaystoneSelectionMenu.java
@@ -54,15 +54,22 @@ public class WaystoneSelectionMenu extends AbstractContainerMenu {
 
     private final Waystone fromWaystone;
     private final Collection<Waystone> waystones;
+    private final List<SharestoneSelectionEntry> restrictedEntries;
     private final Set<ResourceLocation> flags;
     private Consumer<WaystoneTeleportContext> postTeleportHandler = it -> {};
     private ItemStack warpItem = ItemStack.EMPTY;
 
     public WaystoneSelectionMenu(MenuType<WaystoneSelectionMenu> type, @Nullable Waystone fromWaystone, int windowId, Collection<Waystone> waystones, Set<ResourceLocation> flags) {
+        this(type, fromWaystone, windowId, waystones, flags, Collections.emptyList());
+    }
+
+    public WaystoneSelectionMenu(MenuType<WaystoneSelectionMenu> type, @Nullable Waystone fromWaystone, int windowId, Collection<Waystone> waystones,
+                                 Set<ResourceLocation> flags, List<SharestoneSelectionEntry> restrictedEntries) {
         super(type, windowId);
         this.fromWaystone = fromWaystone;
         this.waystones = waystones;
         this.flags = flags;
+        this.restrictedEntries = restrictedEntries;
     }
 
     public WaystoneSelectionMenu withWarpItem(ItemStack warpItem) {
@@ -96,6 +103,14 @@ public class WaystoneSelectionMenu extends AbstractContainerMenu {
 
     public Collection<Waystone> getWaystones() {
         return waystones;
+    }
+
+    public List<SharestoneSelectionEntry> getRestrictedEntries() {
+        return restrictedEntries;
+    }
+
+    public boolean hasRestrictedEntries() {
+        return !restrictedEntries.isEmpty();
     }
 
     public Set<ResourceLocation> getFlags() {

--- a/common/src/main/java/net/blay09/mods/waystones/network/ModNetworking.java
+++ b/common/src/main/java/net/blay09/mods/waystones/network/ModNetworking.java
@@ -17,8 +17,12 @@ public class ModNetworking {
         networking.registerServerboundPacket(RequestManageWaystoneModifiersMessage.TYPE, RequestManageWaystoneModifiersMessage.class, RequestManageWaystoneModifiersMessage::encode, RequestManageWaystoneModifiersMessage::decode, RequestManageWaystoneModifiersMessage::handle);
 
         networking.registerClientboundPacket(UpdateWaystoneMessage.TYPE, UpdateWaystoneMessage.class, UpdateWaystoneMessage::encode, UpdateWaystoneMessage::decode, UpdateWaystoneMessage::handle);
+        networking.registerClientboundPacket(UpdateRestrictedWaystoneMessage.TYPE, UpdateRestrictedWaystoneMessage.class, UpdateRestrictedWaystoneMessage::encode,
+                UpdateRestrictedWaystoneMessage::decode, UpdateRestrictedWaystoneMessage::handle);
         networking.registerClientboundPacket(WaystoneRemovedMessage.TYPE, WaystoneRemovedMessage.class, WaystoneRemovedMessage::encode, WaystoneRemovedMessage::decode, WaystoneRemovedMessage::handle);
         networking.registerClientboundPacket(KnownWaystonesMessage.TYPE, KnownWaystonesMessage.class, KnownWaystonesMessage::encode, KnownWaystonesMessage::decode, KnownWaystonesMessage::handle);
+        networking.registerClientboundPacket(RestrictedWaystonesMessage.TYPE, RestrictedWaystonesMessage.class, RestrictedWaystonesMessage::encode,
+                RestrictedWaystonesMessage::decode, RestrictedWaystonesMessage::handle);
         networking.registerClientboundPacket(SortingIndexMessage.TYPE, SortingIndexMessage.class, SortingIndexMessage::encode, SortingIndexMessage::decode, SortingIndexMessage::handle);
         networking.registerClientboundPacket(TeleportEffectMessage.TYPE, TeleportEffectMessage.class, TeleportEffectMessage::encode, TeleportEffectMessage::decode, TeleportEffectMessage::handle);
         networking.registerClientboundPacket(PlayerWaystoneCooldownsMessage.TYPE, PlayerWaystoneCooldownsMessage.class, PlayerWaystoneCooldownsMessage::encode, PlayerWaystoneCooldownsMessage::decode, PlayerWaystoneCooldownsMessage::handle);

--- a/common/src/main/java/net/blay09/mods/waystones/network/message/RestrictedWaystonesMessage.java
+++ b/common/src/main/java/net/blay09/mods/waystones/network/message/RestrictedWaystonesMessage.java
@@ -1,0 +1,61 @@
+package net.blay09.mods.waystones.network.message;
+
+import net.blay09.mods.balm.api.Balm;
+import net.blay09.mods.waystones.Waystones;
+import net.blay09.mods.waystones.api.Waystone;
+import net.blay09.mods.waystones.api.event.WaystonesListReceivedEvent;
+import net.blay09.mods.waystones.core.WaystoneManagerImpl;
+import net.minecraft.network.RegistryFriendlyByteBuf;
+import net.minecraft.network.protocol.common.custom.CustomPacketPayload;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.entity.player.Player;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class RestrictedWaystonesMessage implements CustomPacketPayload {
+
+    public static final CustomPacketPayload.Type<RestrictedWaystonesMessage> TYPE = new CustomPacketPayload.Type<>(ResourceLocation.fromNamespaceAndPath(
+            Waystones.MOD_ID, "restricted_waystones"));
+
+    private final ResourceLocation type;
+    private final List<SharestoneSyncData> waystones;
+
+    public RestrictedWaystonesMessage(ResourceLocation type, List<SharestoneSyncData> waystones) {
+        this.type = type;
+        this.waystones = waystones;
+    }
+
+    public static void encode(RegistryFriendlyByteBuf buf, RestrictedWaystonesMessage message) {
+        buf.writeResourceLocation(message.type);
+        buf.writeShort(message.waystones.size());
+        for (SharestoneSyncData waystone : message.waystones) {
+            SharestoneSyncData.encode(buf, waystone);
+        }
+    }
+
+    public static RestrictedWaystonesMessage decode(RegistryFriendlyByteBuf buf) {
+        final var type = buf.readResourceLocation();
+        final var waystoneCount = buf.readShort();
+        final List<SharestoneSyncData> waystones = new ArrayList<>();
+        for (int i = 0; i < waystoneCount; i++) {
+            waystones.add(SharestoneSyncData.decode(buf));
+        }
+        return new RestrictedWaystonesMessage(type, waystones);
+    }
+
+    public static void handle(Player player, RestrictedWaystonesMessage message) {
+        final List<Waystone> restrictedWaystones = new ArrayList<>();
+        for (SharestoneSyncData data : message.waystones) {
+            final var restrictedWaystone = data.toRestrictedWaystone();
+            restrictedWaystones.add(restrictedWaystone);
+            WaystoneManagerImpl.get(player.getServer()).updateWaystone(restrictedWaystone);
+        }
+        Balm.getEvents().fireEvent(new WaystonesListReceivedEvent(message.type, restrictedWaystones));
+    }
+
+    @Override
+    public Type<? extends CustomPacketPayload> type() {
+        return TYPE;
+    }
+}

--- a/common/src/main/java/net/blay09/mods/waystones/network/message/SharestoneSyncData.java
+++ b/common/src/main/java/net/blay09/mods/waystones/network/message/SharestoneSyncData.java
@@ -1,0 +1,54 @@
+package net.blay09.mods.waystones.network.message;
+
+import net.blay09.mods.waystones.api.Waystone;
+import net.blay09.mods.waystones.api.WaystoneOrigin;
+import net.blay09.mods.waystones.api.WaystoneVisibility;
+import net.blay09.mods.waystones.core.RestrictedWaystone;
+import net.minecraft.core.registries.Registries;
+import net.minecraft.network.RegistryFriendlyByteBuf;
+import net.minecraft.network.chat.Component;
+import net.minecraft.network.chat.ComponentSerialization;
+import net.minecraft.resources.ResourceKey;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.world.level.Level;
+
+import java.util.UUID;
+
+public record SharestoneSyncData(UUID waystoneId, ResourceLocation waystoneType, Component displayName, WaystoneVisibility visibility, WaystoneOrigin origin,
+                                 ResourceKey<Level> dimension, int distance) {
+
+    public static SharestoneSyncData fromWaystone(ServerPlayer player, Waystone waystone) {
+        int distance = -1;
+        if (player.level().dimension().equals(waystone.getDimension())) {
+            distance = (int) player.position().distanceTo(waystone.getPos().getCenter());
+        }
+        return new SharestoneSyncData(waystone.getWaystoneUid(), waystone.getWaystoneType(), waystone.getName(), waystone.getVisibility(),
+                waystone.getOrigin(), waystone.getDimension(), distance);
+    }
+
+    public static SharestoneSyncData decode(RegistryFriendlyByteBuf buf) {
+        final var waystoneId = buf.readUUID();
+        final var waystoneType = buf.readResourceLocation();
+        final var displayName = ComponentSerialization.STREAM_CODEC.decode(buf);
+        final var visibility = buf.readEnum(WaystoneVisibility.class);
+        final var origin = buf.readEnum(WaystoneOrigin.class);
+        final var dimension = ResourceKey.create(Registries.DIMENSION, buf.readResourceLocation());
+        final var distance = buf.readInt();
+        return new SharestoneSyncData(waystoneId, waystoneType, displayName, visibility, origin, dimension, distance);
+    }
+
+    public static void encode(RegistryFriendlyByteBuf buf, SharestoneSyncData data) {
+        buf.writeUUID(data.waystoneId());
+        buf.writeResourceLocation(data.waystoneType());
+        ComponentSerialization.STREAM_CODEC.encode(buf, data.displayName());
+        buf.writeEnum(data.visibility());
+        buf.writeEnum(data.origin());
+        buf.writeResourceLocation(data.dimension().location());
+        buf.writeInt(data.distance());
+    }
+
+    public RestrictedWaystone toRestrictedWaystone() {
+        return new RestrictedWaystone(waystoneType, waystoneId, origin, dimension, displayName, visibility, distance);
+    }
+}

--- a/common/src/main/java/net/blay09/mods/waystones/network/message/UpdateRestrictedWaystoneMessage.java
+++ b/common/src/main/java/net/blay09/mods/waystones/network/message/UpdateRestrictedWaystoneMessage.java
@@ -1,0 +1,41 @@
+package net.blay09.mods.waystones.network.message;
+
+import net.blay09.mods.balm.api.Balm;
+import net.blay09.mods.waystones.Waystones;
+import net.blay09.mods.waystones.api.event.WaystoneUpdateReceivedEvent;
+import net.blay09.mods.waystones.core.WaystoneManagerImpl;
+import net.minecraft.network.RegistryFriendlyByteBuf;
+import net.minecraft.network.protocol.common.custom.CustomPacketPayload;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.entity.player.Player;
+
+public class UpdateRestrictedWaystoneMessage implements CustomPacketPayload {
+
+    public static final CustomPacketPayload.Type<UpdateRestrictedWaystoneMessage> TYPE = new CustomPacketPayload.Type<>(ResourceLocation.fromNamespaceAndPath(
+            Waystones.MOD_ID, "update_restricted_waystone"));
+
+    private final SharestoneSyncData data;
+
+    public UpdateRestrictedWaystoneMessage(SharestoneSyncData data) {
+        this.data = data;
+    }
+
+    public static void encode(RegistryFriendlyByteBuf buf, UpdateRestrictedWaystoneMessage message) {
+        SharestoneSyncData.encode(buf, message.data);
+    }
+
+    public static UpdateRestrictedWaystoneMessage decode(RegistryFriendlyByteBuf buf) {
+        return new UpdateRestrictedWaystoneMessage(SharestoneSyncData.decode(buf));
+    }
+
+    public static void handle(Player player, UpdateRestrictedWaystoneMessage message) {
+        final var restrictedWaystone = message.data.toRestrictedWaystone();
+        WaystoneManagerImpl.get(player.getServer()).updateWaystone(restrictedWaystone);
+        Balm.getEvents().fireEvent(new WaystoneUpdateReceivedEvent(restrictedWaystone));
+    }
+
+    @Override
+    public Type<? extends CustomPacketPayload> type() {
+        return TYPE;
+    }
+}

--- a/common/src/main/java/net/blay09/mods/waystones/requirement/RequirementRegistry.java
+++ b/common/src/main/java/net/blay09/mods/waystones/requirement/RequirementRegistry.java
@@ -8,6 +8,7 @@ import net.blay09.mods.waystones.api.WaystoneVisibility;
 import net.blay09.mods.waystones.api.requirement.*;
 import net.blay09.mods.waystones.config.WaystonesConfig;
 import net.blay09.mods.waystones.core.PlayerWaystoneManager;
+import net.blay09.mods.waystones.core.WaystoneDistanceProvider;
 import net.blay09.mods.waystones.core.WaystoneTeleportManager;
 import net.blay09.mods.waystones.tag.ModItemTags;
 import net.minecraft.core.registries.BuiltInRegistries;
@@ -368,8 +369,13 @@ public class RequirementRegistry {
                         .equals(parameters.value));
         registerBoundConditionResolver("is_within_distance",
                 FloatParameter.class,
-                (context, parameters) -> (float) Math.sqrt(context.getEntity()
-                        .distanceToSqr(context.getTargetWaystone().getPos().getCenter())) <= parameters.value);
+                (context, parameters) -> {
+                    if (context.getTargetWaystone() instanceof WaystoneDistanceProvider distanceProvider && distanceProvider.hasDistance()) {
+                        return distanceProvider.getDistance() <= parameters.value;
+                    }
+                    return (float) Math.sqrt(context.getEntity()
+                            .distanceToSqr(context.getTargetWaystone().getPos().getCenter())) <= parameters.value;
+                });
         registerConditionResolver("has_cooldown",
                 WaystonesIdParameter.class,
                 (context, parameters) -> {
@@ -416,7 +422,12 @@ public class RequirementRegistry {
                     return false;
                 });
 
-        registerBoundVariableResolver("distance", it -> (float) Math.sqrt(it.getEntity().distanceToSqr(it.getTargetWaystone().getPos().getCenter())));
+        registerBoundVariableResolver("distance", it -> {
+            if (it.getTargetWaystone() instanceof WaystoneDistanceProvider distanceProvider && distanceProvider.hasDistance()) {
+                return distanceProvider.getDistance();
+            }
+            return (float) Math.sqrt(it.getEntity().distanceToSqr(it.getTargetWaystone().getPos().getCenter()));
+        });
         registerVariableResolver("leashed", it -> (float) WaystoneTeleportManager.findLeashedAnimals(it.getEntity()).size());
         registerVariableResolver("pets", it -> (float) WaystoneTeleportManager.findPets(it.getEntity()).size());
         registerVariableResolver("passengers", it -> (float) WaystoneTeleportManager.findPassengers(it.getEntity()).size());


### PR DESCRIPTION
# Add server-controlled Sharestone coordinate privacy (full vs restricted sync) + JourneyMap gating

> **Disclaimer / Status:** I wasn’t able to get the mod to build locally on my end, so this PR is currently **pseudo / unverified** and **needs functional testing** (server + client) to confirm everything behaves as intended and no regressions were introduced.


## PR Summary

- Add **server-side control** over **sharestone coordinate streaming**.
- Support **dual sync paths** (**full coords** vs **restricted data**) for **sharestone GUIs**.
- Preserve the **client-side JourneyMap toggle** while **respecting server policy**.

## Key Changes

- New **server config flag** to **allow/deny sharestone coordinate streaming**.
- **Server-calculated distance payload** for the **sharestone selection GUI**.
- **JourneyMap integration** is **gated for sharestones** when coordinates are disallowed.

## Behavior

- **Coords allowed**
  - Sharestones sync as normal (full coordinate data).
  - JourneyMap (if enabled client-side) can create/update Sharestone waypoints.

- **Coords disallowed**
  - Sharestones sync via a **restricted payload** (no coordinates streamed to clients).
  - Sharestone GUIs still work using restricted entries + **server-computed distance**.
  - JourneyMap integration for Sharestones is **blocked/disabled** under this policy (so it can’t leak coordinates via waypoints).

## Why this matters

Some servers want Sharestones for travel / social gameplay without handing out exact locations to every client (privacy / anti-base-finding). This change makes the server’s policy the source of truth while keeping client features intact when permitted.

## Testing Notes

1. Run a dedicated server + client on this branch.
2. With coordinate streaming **enabled**:
   - Verify Sharestone GUI lists entries and selection works.
   - Verify JourneyMap waypoint behavior works (when enabled client-side).
3. With coordinate streaming **disabled**:
   - Verify Sharestone GUI still lists entries and shows distances (no coordinate leakage).
   - Verify JourneyMap does not create/maintain Sharestone waypoints under server policy.
4. Smoke-test normal waystones to ensure nothing regresses.

## Compatibility / Notes

- This introduces a **new restricted sync path** for Sharestones; client/server should be on matching versions for best results.
- The policy is **server-enforced**: client-side toggles (e.g., JourneyMap integration) remain, but cannot override server restrictions.
