### PR TITLE
Fix item cost showing but not really needed for teleportation

### DIFF
--- a/common/src/main/java/net/blay09/mods/waystones/client/requirement/ItemRequirementRenderer.java
+++ b/common/src/main/java/net/blay09/mods/waystones/client/requirement/ItemRequirementRenderer.java
@@ -8,13 +8,15 @@ import net.minecraft.world.entity.player.Player;
 public class ItemRequirementRenderer implements RequirementRenderer<ItemRequirement> {
     @Override
     public void renderWidget(Player player, ItemRequirement requirement, GuiGraphics guiGraphics, int mouseX, int mouseY, float partialTicks, int x, int y) {
-        final var font = Minecraft.getInstance().font;
-        if (!requirement.canAfford(player)) {
-            guiGraphics.setColor(1f, 1f, 1f, 0.5f);
+        if (requirement.getCount() >= 1) {
+            final var font = Minecraft.getInstance().font;
+            if (!requirement.canAfford(player)) {
+                guiGraphics.setColor(1f, 1f, 1f, 0.5f);
+            }
+            guiGraphics.renderItem(requirement.getItemStack(), x, y, 16, 16);
+            guiGraphics.renderItemDecorations(font, requirement.getItemStack(), x, y, requirement.getCount() > 1 ? String.valueOf(requirement.getCount()) : null);
+            guiGraphics.setColor(1f, 1f, 1f, 1f);
         }
-        guiGraphics.renderItem(requirement.getItemStack(), x, y, 16, 16);
-        guiGraphics.renderItemDecorations(font, requirement.getItemStack(), x, y, requirement.getCount() > 1 ? String.valueOf(requirement.getCount()) : null);
-        guiGraphics.setColor(1f, 1f, 1f, 1f);
     }
 
     @Override


### PR DESCRIPTION
Hi, I discovered a bug when the item cost feature is setup.

I set in the config file "warpRequirements" like that :
```json
[
    "[is_not_interdimensional] scaled_add_item_cost(distance, minecraft:diamond, 0.008)",
    "[is_interdimensional] add_item_cost(minecraft:diamond, 4)",
    "max_item_cost(minecraft:diamond, 8)",
    "[is_with_leashed] scaled_add_item_cost(leashed, minecraft:diamond, 5)",
    "[target_is_global] multiply_item_cost(minecraft:diamond, 0.5)",
    "min_item_cost(minecraft:diamond, 0)"
]
```

Next, in the teleportation menu of the waystone, the prices were incorrect. When the cost was zero, the menu displayed the price of one item (see screenshot below).
<img width="696" height="708" alt="screen_waystone_bug" src="https://github.com/user-attachments/assets/eecba9e6-ee8f-43f1-a911-063c606b0294" />

It's just a display issue because the underlying logic is good (I didn't have a diamond on me when I took the screenshot and the button remains clickable in survival mode).

So I change the render of item cost requirement and It worked well.
<img width="705" height="720" alt="screen_waystone_fix" src="https://github.com/user-attachments/assets/69d6c92d-1561-4bdd-870b-0d29eb20c7e5" />
