### PR TITLE
fix: Change global visibility to use a computed index instead of persisting activations

### DIFF
--- a/common/src/main/java/net/blay09/mods/waystones/core/PlayerWaystoneManager.java
+++ b/common/src/main/java/net/blay09/mods/waystones/core/PlayerWaystoneManager.java
@@ -53,11 +53,12 @@ public class PlayerWaystoneManager {
                 }
 
                 if (!waystone.hasOwner()) {
+                    final var previousVisibility = waystone.getVisibility();
                     mutableWaystone.setOwnerUid(player.getUUID());
                     mutableWaystone.setOwnerUsername(player.getGameProfile().name());
                     mutableWaystone.setVisibility(WaystonesConfig.getActive().rules.defaultVisibility.getVisibility());
                     if (waystone.getVisibility() == WaystoneVisibility.GLOBAL) {
-                        PlayerWaystoneManager.activeWaystoneForEveryone(serverLevel.getServer(), waystone);
+                        WaystoneIndexManager.visibilityChanged(serverLevel.getServer(), waystone, previousVisibility);
                     }
                 }
 
@@ -218,19 +219,6 @@ public class PlayerWaystoneManager {
         getPlayerWaystoneData(player.level()).sortWaystoneGroupSwap(player, groupId, otherGroupId);
     }
 
-    public static void activeWaystoneForEveryone(@Nullable MinecraftServer server, Waystone waystone) {
-        if (server == null) {
-            return;
-        }
-
-        List<ServerPlayer> players = server.getPlayerList().getPlayers();
-        for (ServerPlayer player : players) {
-            if (!isWaystoneActivated(player, waystone)) {
-                activateWaystone(player, waystone);
-            }
-        }
-    }
-
     public static void removeKnownWaystone(@Nullable MinecraftServer server, Waystone waystone) {
         if (server == null) {
             return;
@@ -263,7 +251,7 @@ public class PlayerWaystoneManager {
 
     public static Collection<Waystone> getTargetsForPlayer(ServerPlayer player) {
         final var result = new ArrayList<>(PlayerWaystoneManager.getActivatedWaystones(player));
-        addTeamWaystones(player, result);
+        addThirdPartyWaystones(player, result);
         return result;
     }
 
@@ -319,14 +307,14 @@ public class PlayerWaystoneManager {
         return result;
     }
 
-    private static void addTeamWaystones(ServerPlayer player, Collection<Waystone> result) {
+    private static void addThirdPartyWaystones(ServerPlayer player, Collection<Waystone> result) {
         // Keep track of ones we're already listing from other sources to avoid duplicates below
         final var knownWaystoneIds = new HashSet<UUID>();
         for (final var waystone : result) {
             knownWaystoneIds.add(waystone.getWaystoneUid());
         }
 
-        for (final var waystone : TeamWaystoneManager.getTargets(player)) {
+        for (final var waystone : WaystoneIndexManager.getTargets(player)) {
             if (knownWaystoneIds.add(waystone.getWaystoneUid())) {
                 result.add(waystone);
             }

--- a/common/src/main/java/net/blay09/mods/waystones/core/WaystoneIndexManager.java
+++ b/common/src/main/java/net/blay09/mods/waystones/core/WaystoneIndexManager.java
@@ -11,26 +11,28 @@ import net.minecraft.world.scores.PlayerTeam;
 
 import java.util.*;
 
-public class TeamWaystoneManager {
+public class WaystoneIndexManager {
 
     private static final SetMultimap<String, UUID> waystonesByTeamName = MultimapBuilder.hashKeys().linkedHashSetValues().build();
+    private static final Set<UUID> globalWaystones = new LinkedHashSet<>();
 
     public static void rebuildIndex(MinecraftServer server) {
         waystonesByTeamName.clear();
+        globalWaystones.clear();
         for (final var waystone : SavedDataWaystonesStore.get(server).getWaystones()) {
-            if (waystone.getVisibility() == WaystoneVisibility.TEAM) {
-                add(server, waystone);
-            }
+            add(server, waystone);
         }
     }
 
     public static void visibilityChanged(MinecraftServer server, Waystone waystone, WaystoneVisibility previousVisibility) {
-        if (previousVisibility == WaystoneVisibility.TEAM) {
+        if (previousVisibility == WaystoneVisibility.TEAM || previousVisibility == WaystoneVisibility.GLOBAL) {
             remove(waystone);
         }
-        if (waystone.getVisibility() == WaystoneVisibility.TEAM) {
-            add(server, waystone);
-        }
+        add(server, waystone);
+    }
+
+    public static void waystoneRemoved(Waystone waystone) {
+        remove(waystone);
     }
 
     public static void playerTeamChanged(MinecraftServer server, String playerName) {
@@ -45,6 +47,28 @@ public class TeamWaystoneManager {
     }
 
     public static Collection<Waystone> getTargets(ServerPlayer player) {
+        final var result = new ArrayList<Waystone>();
+        result.addAll(getGlobalTargets(player));
+        result.addAll(getTeamTargets(player));
+        return result;
+    }
+
+    private static Collection<Waystone> getGlobalTargets(ServerPlayer player) {
+        if (globalWaystones.isEmpty()) {
+            return List.of();
+        }
+
+        final var store = SavedDataWaystonesStore.get(player.level().getServer());
+        final var result = new ArrayList<Waystone>();
+        for (final var waystoneId : globalWaystones) {
+            store.getWaystoneById(waystoneId)
+                    .filter(waystone -> waystone.getVisibility() == WaystoneVisibility.GLOBAL)
+                    .ifPresent(result::add);
+        }
+        return result;
+    }
+
+    private static Collection<Waystone> getTeamTargets(ServerPlayer player) {
         final var team = player.getTeam();
         if (team == null) {
             return List.of();
@@ -66,6 +90,15 @@ public class TeamWaystoneManager {
     }
 
     private static void add(MinecraftServer server, Waystone waystone) {
+        if (waystone.getVisibility() == WaystoneVisibility.GLOBAL) {
+            globalWaystones.add(waystone.getWaystoneUid());
+            return;
+        }
+
+        if (waystone.getVisibility() != WaystoneVisibility.TEAM) {
+            return;
+        }
+
         PlayerWaystoneManager.getOwnerUsername(waystone, server)
                 .map(ownerUsername -> server.getScoreboard().getPlayersTeam(ownerUsername))
                 .map(PlayerTeam::getName)
@@ -73,6 +106,7 @@ public class TeamWaystoneManager {
     }
 
     private static void remove(Waystone waystone) {
+        globalWaystones.remove(waystone.getWaystoneUid());
         waystonesByTeamName.values().remove(waystone.getWaystoneUid());
     }
 }

--- a/common/src/main/java/net/blay09/mods/waystones/handler/LoginHandler.java
+++ b/common/src/main/java/net/blay09/mods/waystones/handler/LoginHandler.java
@@ -1,27 +1,14 @@
 package net.blay09.mods.waystones.handler;
 
 import net.blay09.mods.balm.platform.event.callback.ServerPlayerCallback;
-import net.blay09.mods.waystones.api.Waystone;
 import net.blay09.mods.waystones.api.WaystoneKinds;
-import net.blay09.mods.waystones.core.PlayerWaystoneManager;
-import net.blay09.mods.waystones.store.SavedDataWaystonesStore;
 import net.blay09.mods.waystones.core.WaystoneSyncManager;
 import net.minecraft.resources.Identifier;
-
-import java.util.List;
 
 public class LoginHandler {
 
     public static void register() {
         ServerPlayerCallback.Join.EVENT.register(player -> {
-            // Introduce all global waystones to this player
-            List<Waystone> globalWaystones = SavedDataWaystonesStore.get(player.level().getServer()).getGlobalWaystones();
-            for (Waystone waystone : globalWaystones) {
-                if (!PlayerWaystoneManager.isWaystoneActivated(player, waystone)) {
-                    PlayerWaystoneManager.activateWaystone(player, waystone);
-                }
-            }
-
             WaystoneSyncManager.sendSortingIndex(player);
             WaystoneSyncManager.ensureDynamicGroups(player);
             WaystoneSyncManager.sendWaystoneGroups(player);

--- a/common/src/main/java/net/blay09/mods/waystones/handler/ModEventHandlers.java
+++ b/common/src/main/java/net/blay09/mods/waystones/handler/ModEventHandlers.java
@@ -4,14 +4,14 @@ import net.blay09.mods.balm.platform.event.callback.ServerLifecycleCallback;
 import net.blay09.mods.waystones.api.event.WaystoneActivatedEvent;
 import net.blay09.mods.waystones.api.event.WaystoneTeleportEvent;
 import net.blay09.mods.waystones.core.FleetingMemorialManager;
-import net.blay09.mods.waystones.core.TeamWaystoneManager;
+import net.blay09.mods.waystones.core.WaystoneIndexManager;
 
 public class ModEventHandlers {
     public static void initialize() {
         LoginHandler.register();
         WarpDamageResetHandler.register();
         WarpDamageResetHandler.register();
-        ServerLifecycleCallback.Started.EVENT.register(TeamWaystoneManager::rebuildIndex);
+        ServerLifecycleCallback.Started.EVENT.register(WaystoneIndexManager::rebuildIndex);
         EpitaphDeathHandler.register();
         WaystoneActivatedEvent.EVENT.register(WaystoneActivationStatHandler::onWaystoneActivated);
         WaystoneTeleportEvent.After.EVENT.register(FleetingMemorialManager::handleTeleportAfter);

--- a/common/src/main/java/net/blay09/mods/waystones/mixin/ServerScoreboardMixin.java
+++ b/common/src/main/java/net/blay09/mods/waystones/mixin/ServerScoreboardMixin.java
@@ -1,6 +1,6 @@
 package net.blay09.mods.waystones.mixin;
 
-import net.blay09.mods.waystones.core.TeamWaystoneManager;
+import net.blay09.mods.waystones.core.WaystoneIndexManager;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.ServerScoreboard;
 import net.minecraft.world.scores.PlayerTeam;
@@ -22,12 +22,12 @@ public class ServerScoreboardMixin {
     @Inject(method = "addPlayerToTeam", at = @At("RETURN"))
     private void addPlayerToTeam(String player, PlayerTeam team, CallbackInfoReturnable<Boolean> callbackInfo) {
         if (callbackInfo.getReturnValue()) {
-            TeamWaystoneManager.playerTeamChanged(server, player);
+            WaystoneIndexManager.playerTeamChanged(server, player);
         }
     }
 
     @Inject(method = "removePlayerFromTeam(Ljava/lang/String;Lnet/minecraft/world/scores/PlayerTeam;)V", at = @At("RETURN"))
     private void removePlayerFromTeam(String player, PlayerTeam team, CallbackInfo callbackInfo) {
-        TeamWaystoneManager.playerTeamChanged(server, player);
+        WaystoneIndexManager.playerTeamChanged(server, player);
     }
 }

--- a/common/src/main/java/net/blay09/mods/waystones/network/message/ServerboundEditWaystonePacket.java
+++ b/common/src/main/java/net/blay09/mods/waystones/network/message/ServerboundEditWaystonePacket.java
@@ -61,12 +61,9 @@ public record ServerboundEditWaystonePacket(UUID waystoneUid, String name, Wayst
         backingWaystone.setName(legalName);
 
         final var previousVisibility = backingWaystone.getVisibility();
-        if (visibility == WaystoneVisibility.GLOBAL && backingWaystone.getVisibility() != WaystoneVisibility.GLOBAL) {
-            PlayerWaystoneManager.activeWaystoneForEveryone(server, backingWaystone);
-        }
         backingWaystone.setVisibility(visibility);
 
-        TeamWaystoneManager.visibilityChanged(server, backingWaystone, previousVisibility);
+        WaystoneIndexManager.visibilityChanged(server, backingWaystone, previousVisibility);
         SavedDataWaystonesStore.get(server).setDirty();
         WaystoneSyncManager.sendWaystoneUpdateToAll(server, backingWaystone);
 

--- a/common/src/main/java/net/blay09/mods/waystones/network/message/ServerboundRemoveWaystonePacket.java
+++ b/common/src/main/java/net/blay09/mods/waystones/network/message/ServerboundRemoveWaystonePacket.java
@@ -42,10 +42,10 @@ public record ServerboundRemoveWaystonePacket(UUID waystoneUid) implements Custo
                 if (backingWaystone instanceof MutableWaystone mutableWaystone) {
                     final var previousVisibility = backingWaystone.getVisibility();
                     mutableWaystone.setVisibility(WaystoneVisibility.ACTIVATION);
-                    TeamWaystoneManager.visibilityChanged(server, backingWaystone, previousVisibility);
+                    WaystoneIndexManager.visibilityChanged(server, backingWaystone, previousVisibility);
 
                     // Check if the waystone block still exists - if not, completely remove the waystone from existence to remove it from all players
-                    // This way we can't have orphan global waystones left over. And just in case the waystone *was* just being silk-touch moved, it's easy to reactivate a global waystone for everyone (since it does that automatically).
+                    // This way we can't have orphan global waystones left over.
                     ServerLevel targetWorld = Objects.requireNonNull(player.level().getServer()).getLevel(backingWaystone.getDimension());
                     BlockPos pos = backingWaystone.getPos();
                     BlockState state = targetWorld != null ? targetWorld.getBlockState(pos) : null;

--- a/common/src/main/java/net/blay09/mods/waystones/store/SavedDataWaystonesStore.java
+++ b/common/src/main/java/net/blay09/mods/waystones/store/SavedDataWaystonesStore.java
@@ -3,6 +3,7 @@ package net.blay09.mods.waystones.store;
 import com.mojang.serialization.Codec;
 import com.mojang.serialization.codecs.RecordCodecBuilder;
 import net.blay09.mods.waystones.api.*;
+import net.blay09.mods.waystones.core.WaystoneIndexManager;
 import net.blay09.mods.waystones.core.WaystoneImpl;
 import net.minecraft.core.BlockPos;
 import net.minecraft.resources.Identifier;
@@ -49,6 +50,7 @@ public class SavedDataWaystonesStore extends SavedData implements WaystonesStore
 
     @Override
     public void removeWaystone(Waystone waystone) {
+        WaystoneIndexManager.waystoneRemoved(waystone);
         store.removeWaystone(waystone);
         setDirty();
     }


### PR DESCRIPTION
Many years ago it was easiest to persist activations for global waystones because the selection was built client-side from a synced list, but that's all different since at least 1.21.1 if not earlier.

Treating global waystones as "third party" additions to the list is much cleaner, because it means players won't accidentally get access to waystones just because the owner was toggling through the visibility button, and it allows undoing making something global.

With this change, new global waystones will appear unactivated unless the player has actually explicitly activated it.