### PR TITLE
fix: hide warp modifier UI when teleports.enableModifiers is false

### DIFF
--- a/common/src/main/java/net/blay09/mods/waystones/block/entity/WaystoneBlockEntityBase.java
+++ b/common/src/main/java/net/blay09/mods/waystones/block/entity/WaystoneBlockEntityBase.java
@@ -15,6 +15,7 @@ import net.blay09.mods.waystones.api.error.WaystoneEditError;
 import net.blay09.mods.waystones.block.WaystoneBlock;
 import net.blay09.mods.waystones.block.WaystoneBlockBase;
 import net.blay09.mods.waystones.component.ModComponents;
+import net.blay09.mods.waystones.config.WaystonesConfig;
 import net.blay09.mods.waystones.core.*;
 import net.blay09.mods.waystones.item.ModItems;
 import net.blay09.mods.waystones.menu.WaystoneEditMenu;
@@ -322,6 +323,9 @@ public abstract class WaystoneBlockEntityBase extends BalmBlockEntity implements
     }
 
     public Optional<MenuProvider> getModifierMenuProvider(ServerPlayer player) {
+        if (!WaystonesConfig.getActive().teleports.enableModifiers) {
+            return Optional.empty();
+        }
         final var waystone = PlayerWaystoneManager.getPlayerDecoratedWaystone(player, getWaystone());
         return Optional.of(new BalmMenuProvider<PersonalizedWaystoneImpl>() {
             @Override

--- a/common/src/main/java/net/blay09/mods/waystones/client/gui/screen/WaystoneEditScreen.java
+++ b/common/src/main/java/net/blay09/mods/waystones/client/gui/screen/WaystoneEditScreen.java
@@ -2,6 +2,7 @@ package net.blay09.mods.waystones.client.gui.screen;
 
 import net.blay09.mods.balm.api.Balm;
 import net.blay09.mods.waystones.client.gui.widget.WaystoneVisbilityButton;
+import net.blay09.mods.waystones.config.WaystonesConfig;
 import net.blay09.mods.waystones.core.PlayerWaystoneManager;
 import net.blay09.mods.waystones.menu.WaystoneEditMenu;
 import net.blay09.mods.waystones.network.message.EditWaystoneMessage;
@@ -83,21 +84,25 @@ public class WaystoneEditScreen extends WaystoneContainerScreen<WaystoneEditMenu
         addRenderableWidget(visibilityButton);
         y += 24;
 
-        final var modifierSprites = new WidgetSprites(
-                id("edit_waystone/modifier_button"),
-                id("edit_waystone/modifier_button_highlighted"));
-        modifierButton = new ImageButton(20,
-                20,
-                modifierSprites,
-                button -> {
-                    saveWaystoneSettings();
-                    Balm.getNetworking().sendToServer(new RequestManageWaystoneModifiersMessage(menu.getWaystone().getPos()));
-                },
-                Component.translatable("gui.waystones.waystone_settings.manage_modifiers"));
-        modifierButton.setPosition(leftPos, y);
-        modifierButton.active = menu.canEdit();
-        addRenderableWidget(modifierButton);
-        y += 24;
+        if (WaystonesConfig.getActive().teleports.enableModifiers) {
+            final var modifierSprites = new WidgetSprites(
+                    id("edit_waystone/modifier_button"),
+                    id("edit_waystone/modifier_button_highlighted"));
+            modifierButton = new ImageButton(20,
+                    20,
+                    modifierSprites,
+                    button -> {
+                        saveWaystoneSettings();
+                        Balm.getNetworking().sendToServer(new RequestManageWaystoneModifiersMessage(menu.getWaystone().getPos()));
+                    },
+                    Component.translatable("gui.waystones.waystone_settings.manage_modifiers"));
+            modifierButton.setPosition(leftPos, y);
+            modifierButton.active = menu.canEdit();
+            addRenderableWidget(modifierButton);
+            y += 24;
+        } else {
+            modifierButton = null;
+        }
 
         final var saveButton = Button.builder(
                         Component.translatable(menu.canEdit() ? "gui.waystones.waystone_settings.save" : "gui.waystones.waystone_settings.close"),

--- a/common/src/main/java/net/blay09/mods/waystones/network/message/RequestManageWaystoneModifiersMessage.java
+++ b/common/src/main/java/net/blay09/mods/waystones/network/message/RequestManageWaystoneModifiersMessage.java
@@ -3,6 +3,7 @@ package net.blay09.mods.waystones.network.message;
 import net.blay09.mods.balm.api.Balm;
 import net.blay09.mods.waystones.Waystones;
 import net.blay09.mods.waystones.block.entity.WaystoneBlockEntityBase;
+import net.blay09.mods.waystones.config.WaystonesConfig;
 import net.minecraft.core.BlockPos;
 import net.minecraft.network.FriendlyByteBuf;
 import net.minecraft.network.protocol.common.custom.CustomPacketPayload;
@@ -31,6 +32,9 @@ public class RequestManageWaystoneModifiersMessage implements CustomPacketPayloa
     }
 
     public static void handle(ServerPlayer player, RequestManageWaystoneModifiersMessage message) {
+        if (!WaystonesConfig.getActive().teleports.enableModifiers) {
+            return;
+        }
         final var level = player.level();
         final var blockEntity = level.isLoaded(message.pos) ? level.getBlockEntity(message.pos) : null;
         if (blockEntity instanceof WaystoneBlockEntityBase waystoneBlockEntity) {


### PR DESCRIPTION
## Summary
- When `teleports.enableModifiers` is false, hide the waystone edit-screen modifier button and status text.
- Return no modifier menu provider and ignore the manage-modifiers packet in that case.
- Upstream already disables applying modifier effects via this config; this makes the UI and menus match.

## Test plan
- [ ] With `enableModifiers = false`, edit screen has no modifier button/label
- [ ] Manage-modifiers menu does not open when disabled
- [ ] With `enableModifiers = true`, modifier UI and menus still work