### PR TITLE
fix: Backport Vanilla bugfix for entity teleportation to 1.21.1

### DIFF
--- a/common/src/main/java/net/blay09/mods/waystones/config/WaystonesConfigData.java
+++ b/common/src/main/java/net/blay09/mods/waystones/config/WaystonesConfigData.java
@@ -162,6 +162,9 @@ public class WaystonesConfigData implements BalmConfigData {
 
         @Comment("If enabled, Waystones will add markers for waystones and sharestones to Dynmap.")
         public boolean dynmap = true;
+
+        @Comment("Set to true to apply Waystones' entity teleport packet fix to all entity teleports, including vanilla and other mods.")
+        public boolean fixVanillaTeleportBug = false;
     }
 
     public static class BlueMap {

--- a/common/src/main/java/net/blay09/mods/waystones/core/EntityTeleportBatch.java
+++ b/common/src/main/java/net/blay09/mods/waystones/core/EntityTeleportBatch.java
@@ -4,6 +4,8 @@ import net.blay09.mods.waystones.api.EntityTeleportResult;
 import net.blay09.mods.waystones.api.TeleportDestination;
 import net.blay09.mods.waystones.api.WaystoneTeleportContext;
 import net.blay09.mods.waystones.api.WaystoneTeleportResult;
+import net.minecraft.network.protocol.game.ClientboundMoveVehiclePacket;
+import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.Mob;
 import org.jetbrains.annotations.Nullable;
@@ -114,6 +116,11 @@ public class EntityTeleportBatch {
 
             mount.ejectPassengers();
             desiredPassengers.forEach(passenger -> passenger.startRiding(mount, true));
+
+            // Send a manual update to the controlling player to avoid snapping back to the original position on close-range teleports
+            if (mount.getControllingPassenger() instanceof ServerPlayer player) {
+                player.connection.send(new ClientboundMoveVehiclePacket(mount));
+            }
         });
     }
 

--- a/common/src/main/java/net/blay09/mods/waystones/core/WaystoneTeleportManager.java
+++ b/common/src/main/java/net/blay09/mods/waystones/core/WaystoneTeleportManager.java
@@ -146,7 +146,6 @@ public class WaystoneTeleportManager {
         batch.restoreMounts();
 
         final var teleportedEntities = result.teleportedEntities();
-        teleportedEntities.forEach(WaystoneTeleportManager::forceEntityTrackingRefresh);
         final var sourcePos = context.getEntity().blockPosition();
         final var targetLevel = (ServerLevel) destination.level();
         final var targetPos = BlockPos.containing(destination.location());
@@ -296,23 +295,6 @@ public class WaystoneTeleportManager {
         if (entity instanceof ServerPlayer player) {
             // No idea why this is still needed since we're using the same code as /tp. Maybe /tp is broken too for interdimensional travel.
             player.connection.send(new ClientboundSetExperiencePacket(player.experienceProgress, player.totalExperience, player.experienceLevel));
-        }
-    }
-
-    /**
-     * This is necessary because there seems to be a Vanilla bug that does not properly update entity tracking for players in the target area.
-     * You can reproduce the bug by having two players far from each other, spawning some donkeys, and running `/tp @e[type=donkey] @s` on the other.
-     * The donkeys will teleport, but not be visible for the target player until they relog or re-enter the area.
-     */
-    private static void forceEntityTrackingRefresh(Entity entity) {
-        if (entity.level() instanceof ServerLevel level && !entity.isRemoved()) {
-            final var chunkSource = level.getChunkSource();
-            if (entity instanceof ServerPlayer player) {
-                chunkSource.move(player);
-            } else {
-                chunkSource.removeEntity(entity);
-                chunkSource.addEntity(entity);
-            }
         }
     }
 

--- a/common/src/main/java/net/blay09/mods/waystones/core/WaystoneTeleportManager.java
+++ b/common/src/main/java/net/blay09/mods/waystones/core/WaystoneTeleportManager.java
@@ -232,6 +232,7 @@ public class WaystoneTeleportManager {
             ((PathfinderMob) entity).getNavigation().stop();
         }
 
+        ((WaystoneTeleportedEntity) entity).waystones$markTeleportedByWaystone();
         sendHackySyncPacketsAfterTeleport(entity);
 
         final var teleportResult = EntityTeleportResult.success(entity, destination, new TeleportDestination(targetLevel, targetPosition, direction));

--- a/common/src/main/java/net/blay09/mods/waystones/core/WaystoneTeleportedEntity.java
+++ b/common/src/main/java/net/blay09/mods/waystones/core/WaystoneTeleportedEntity.java
@@ -1,0 +1,8 @@
+package net.blay09.mods.waystones.core;
+
+public interface WaystoneTeleportedEntity {
+
+    void waystones$markTeleportedByWaystone();
+
+    boolean waystones$consumeTeleportedByWaystone();
+}

--- a/common/src/main/java/net/blay09/mods/waystones/mixin/ClientLevelAccessor.java
+++ b/common/src/main/java/net/blay09/mods/waystones/mixin/ClientLevelAccessor.java
@@ -1,0 +1,13 @@
+package net.blay09.mods.waystones.mixin;
+
+import net.minecraft.client.multiplayer.ClientLevel;
+import net.minecraft.world.level.entity.EntityTickList;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.gen.Accessor;
+
+@Mixin(ClientLevel.class)
+public interface ClientLevelAccessor {
+
+    @Accessor("tickingEntities")
+    EntityTickList waystones$getTickingEntities();
+}

--- a/common/src/main/java/net/blay09/mods/waystones/mixin/EntityMixin.java
+++ b/common/src/main/java/net/blay09/mods/waystones/mixin/EntityMixin.java
@@ -1,0 +1,28 @@
+package net.blay09.mods.waystones.mixin;
+
+import net.blay09.mods.waystones.core.WaystoneTeleportedEntity;
+import net.minecraft.world.entity.Entity;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Unique;
+
+@Mixin(Entity.class)
+public class EntityMixin implements WaystoneTeleportedEntity {
+
+    @Unique
+    private boolean waystones$teleportedByWaystone;
+
+    @Override
+    public void waystones$markTeleportedByWaystone() {
+        waystones$teleportedByWaystone = true;
+    }
+
+    @Override
+    public boolean waystones$consumeTeleportedByWaystone() {
+        if (waystones$teleportedByWaystone) {
+            waystones$teleportedByWaystone = false;
+            return true;
+        }
+
+        return false;
+    }
+}

--- a/common/src/main/java/net/blay09/mods/waystones/mixin/ServerEntityMixin.java
+++ b/common/src/main/java/net/blay09/mods/waystones/mixin/ServerEntityMixin.java
@@ -1,0 +1,35 @@
+package net.blay09.mods.waystones.mixin;
+
+import net.blay09.mods.waystones.config.WaystonesConfig;
+import net.blay09.mods.waystones.core.WaystoneTeleportedEntity;
+import net.blay09.mods.waystones.network.message.ClientboundEntityPositionSyncMessage;
+import net.minecraft.network.protocol.common.ClientboundCustomPayloadPacket;
+import net.minecraft.network.protocol.game.ClientboundTeleportEntityPacket;
+import net.minecraft.server.level.ServerEntity;
+import net.minecraft.world.entity.Entity;
+import org.spongepowered.asm.mixin.Final;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.ModifyArg;
+
+@Mixin(ServerEntity.class)
+public class ServerEntityMixin {
+
+    @Shadow
+    @Final
+    private Entity entity;
+
+    @ModifyArg(method = "sendChanges", at = @At(value = "INVOKE", target = "Ljava/util/function/Consumer;accept(Ljava/lang/Object;)V"))
+    private Object replaceTeleportEntityPacket(Object packet) {
+        if (packet instanceof ClientboundTeleportEntityPacket) {
+            if (WaystonesConfig.getActive().compatibility.fixVanillaTeleportBug
+                    || ((WaystoneTeleportedEntity) entity).waystones$consumeTeleportedByWaystone()) {
+                return new ClientboundCustomPayloadPacket(new ClientboundEntityPositionSyncMessage(entity));
+            }
+        }
+
+        return packet;
+    }
+
+}

--- a/common/src/main/java/net/blay09/mods/waystones/network/ModNetworking.java
+++ b/common/src/main/java/net/blay09/mods/waystones/network/ModNetworking.java
@@ -34,6 +34,7 @@ public class ModNetworking {
         networking.registerClientboundPacket(PlayerWaystoneCooldownsMessage.TYPE, PlayerWaystoneCooldownsMessage.class, PlayerWaystoneCooldownsMessage::encode, PlayerWaystoneCooldownsMessage::decode, PlayerWaystoneCooldownsMessage::handle);
         networking.registerClientboundPacket(WarpPlateEjectEffectMessage.TYPE, WarpPlateEjectEffectMessage.class, WarpPlateEjectEffectMessage::encode, WarpPlateEjectEffectMessage::decode, WarpPlateEjectEffectMessage::handle);
         networking.registerClientboundPacket(ClientboundEpitaphActivationPacket.TYPE, ClientboundEpitaphActivationPacket.class, ClientboundEpitaphActivationPacket::encode, ClientboundEpitaphActivationPacket::decode, ClientboundEpitaphActivationPacket::handle);
+        networking.registerClientboundPacket(ClientboundEntityPositionSyncMessage.TYPE, ClientboundEntityPositionSyncMessage.class, ClientboundEntityPositionSyncMessage::encode, ClientboundEntityPositionSyncMessage::decode, ClientboundEntityPositionSyncMessage::handle);
 
         SyncConfigMessage.register(SyncWaystonesConfigMessage.TYPE, SyncWaystonesConfigMessage.class, SyncWaystonesConfigMessage::new, WaystonesConfigData.class, WaystonesConfigData::new);
     }

--- a/common/src/main/java/net/blay09/mods/waystones/network/message/ClientboundEntityPositionSyncMessage.java
+++ b/common/src/main/java/net/blay09/mods/waystones/network/message/ClientboundEntityPositionSyncMessage.java
@@ -1,0 +1,102 @@
+package net.blay09.mods.waystones.network.message;
+
+import net.blay09.mods.waystones.Waystones;
+import net.blay09.mods.waystones.mixin.ClientLevelAccessor;
+import net.minecraft.client.multiplayer.ClientLevel;
+import net.minecraft.network.FriendlyByteBuf;
+import net.minecraft.network.protocol.common.custom.CustomPacketPayload;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.entity.Entity;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.phys.Vec3;
+
+public class ClientboundEntityPositionSyncMessage implements CustomPacketPayload {
+
+    public static final Type<ClientboundEntityPositionSyncMessage> TYPE = new Type<>(ResourceLocation.fromNamespaceAndPath(Waystones.MOD_ID,
+            "entity_position_sync"));
+    private static final double SNAP_DISTANCE_SQUARED = 4096.0;
+
+    private final int entityId;
+    private final Vec3 position;
+    private final Vec3 deltaMovement;
+    private final float yRot;
+    private final float xRot;
+    private final boolean onGround;
+
+    public ClientboundEntityPositionSyncMessage(Entity entity) {
+        this(entity.getId(), entity.trackingPosition(), entity.getDeltaMovement(), entity.getYRot(), entity.getXRot(), entity.onGround());
+    }
+
+    public ClientboundEntityPositionSyncMessage(int entityId, Vec3 position, Vec3 deltaMovement, float yRot, float xRot, boolean onGround) {
+        this.entityId = entityId;
+        this.position = position;
+        this.deltaMovement = deltaMovement;
+        this.yRot = yRot;
+        this.xRot = xRot;
+        this.onGround = onGround;
+    }
+
+    public static void encode(FriendlyByteBuf buf, ClientboundEntityPositionSyncMessage message) {
+        buf.writeVarInt(message.entityId);
+        writeVec3(buf, message.position);
+        writeVec3(buf, message.deltaMovement);
+        buf.writeFloat(message.yRot);
+        buf.writeFloat(message.xRot);
+        buf.writeBoolean(message.onGround);
+    }
+
+    public static ClientboundEntityPositionSyncMessage decode(FriendlyByteBuf buf) {
+        return new ClientboundEntityPositionSyncMessage(buf.readVarInt(), readVec3(buf), readVec3(buf), buf.readFloat(), buf.readFloat(), buf.readBoolean());
+    }
+
+    public static void handle(Player player, ClientboundEntityPositionSyncMessage message) {
+        final var entity = player.level().getEntity(message.entityId);
+        if (entity == null) {
+            return;
+        }
+
+        entity.syncPacketPositionCodec(message.position.x, message.position.y, message.position.z);
+        entity.setDeltaMovement(message.deltaMovement);
+
+        if (!entity.isControlledByLocalInstance()) {
+            if (shouldSnap(player, entity, message.position)) {
+                entity.moveTo(message.position, message.yRot, message.xRot);
+                if (entity.hasIndirectPassenger(player)) {
+                    entity.positionRider(player);
+                    player.setOldPosAndRot();
+                }
+            } else {
+                entity.lerpTo(message.position.x, message.position.y, message.position.z, message.yRot, message.xRot, 3);
+            }
+
+            entity.setOnGround(message.onGround);
+        }
+    }
+
+    private static boolean shouldSnap(Player player, Entity entity, Vec3 position) {
+        return entity.position().distanceToSqr(position) > SNAP_DISTANCE_SQUARED || !isTicking(player, entity);
+    }
+
+    private static boolean isTicking(Player player, Entity entity) {
+        if (player.level() instanceof ClientLevel clientLevel) {
+            return ((ClientLevelAccessor) clientLevel).waystones$getTickingEntities().contains(entity);
+        }
+
+        return true;
+    }
+
+    private static void writeVec3(FriendlyByteBuf buf, Vec3 vec) {
+        buf.writeDouble(vec.x);
+        buf.writeDouble(vec.y);
+        buf.writeDouble(vec.z);
+    }
+
+    private static Vec3 readVec3(FriendlyByteBuf buf) {
+        return new Vec3(buf.readDouble(), buf.readDouble(), buf.readDouble());
+    }
+
+    @Override
+    public Type<? extends CustomPacketPayload> type() {
+        return TYPE;
+    }
+}

--- a/common/src/main/java/net/blay09/mods/waystones/network/message/ClientboundEntityPositionSyncMessage.java
+++ b/common/src/main/java/net/blay09/mods/waystones/network/message/ClientboundEntityPositionSyncMessage.java
@@ -14,7 +14,6 @@ public class ClientboundEntityPositionSyncMessage implements CustomPacketPayload
 
     public static final Type<ClientboundEntityPositionSyncMessage> TYPE = new Type<>(ResourceLocation.fromNamespaceAndPath(Waystones.MOD_ID,
             "entity_position_sync"));
-    private static final double SNAP_DISTANCE_SQUARED = 4096.0;
 
     private final int entityId;
     private final Vec3 position;
@@ -38,15 +37,15 @@ public class ClientboundEntityPositionSyncMessage implements CustomPacketPayload
 
     public static void encode(FriendlyByteBuf buf, ClientboundEntityPositionSyncMessage message) {
         buf.writeVarInt(message.entityId);
-        writeVec3(buf, message.position);
-        writeVec3(buf, message.deltaMovement);
+        buf.writeVec3(message.position);
+        buf.writeVec3(message.deltaMovement);
         buf.writeFloat(message.yRot);
         buf.writeFloat(message.xRot);
         buf.writeBoolean(message.onGround);
     }
 
     public static ClientboundEntityPositionSyncMessage decode(FriendlyByteBuf buf) {
-        return new ClientboundEntityPositionSyncMessage(buf.readVarInt(), readVec3(buf), readVec3(buf), buf.readFloat(), buf.readFloat(), buf.readBoolean());
+        return new ClientboundEntityPositionSyncMessage(buf.readVarInt(), buf.readVec3(), buf.readVec3(), buf.readFloat(), buf.readFloat(), buf.readBoolean());
     }
 
     public static void handle(Player player, ClientboundEntityPositionSyncMessage message) {
@@ -59,7 +58,8 @@ public class ClientboundEntityPositionSyncMessage implements CustomPacketPayload
         entity.setDeltaMovement(message.deltaMovement);
 
         if (!entity.isControlledByLocalInstance()) {
-            if (shouldSnap(player, entity, message.position)) {
+            boolean tooBigToInterpolate = entity.position().distanceToSqr(message.position) > 4096;
+            if (tooBigToInterpolate || isTickingEntity(entity)) {
                 entity.moveTo(message.position, message.yRot, message.xRot);
                 if (entity.hasIndirectPassenger(player)) {
                     entity.positionRider(player);
@@ -73,26 +73,12 @@ public class ClientboundEntityPositionSyncMessage implements CustomPacketPayload
         }
     }
 
-    private static boolean shouldSnap(Player player, Entity entity, Vec3 position) {
-        return entity.position().distanceToSqr(position) > SNAP_DISTANCE_SQUARED || !isTicking(player, entity);
-    }
-
-    private static boolean isTicking(Player player, Entity entity) {
-        if (player.level() instanceof ClientLevel clientLevel) {
+    private static boolean isTickingEntity(Entity entity) {
+        if (entity.level() instanceof ClientLevel clientLevel) {
             return ((ClientLevelAccessor) clientLevel).waystones$getTickingEntities().contains(entity);
         }
 
         return true;
-    }
-
-    private static void writeVec3(FriendlyByteBuf buf, Vec3 vec) {
-        buf.writeDouble(vec.x);
-        buf.writeDouble(vec.y);
-        buf.writeDouble(vec.z);
-    }
-
-    private static Vec3 readVec3(FriendlyByteBuf buf) {
-        return new Vec3(buf.readDouble(), buf.readDouble(), buf.readDouble());
     }
 
     @Override

--- a/common/src/main/resources/assets/waystones/lang/en_us.json
+++ b/common/src/main/resources/assets/waystones/lang/en_us.json
@@ -335,6 +335,8 @@
   "waystones.configuration.compatibility.preferJourneyMapIntegrationMod.tooltip": "If enabled, JourneyMap waypoints will only be created if the mod 'JourneyMap Integration' is not installed.",
   "waystones.configuration.compatibility.dynmap": "Enable Dynmap Support",
   "waystones.configuration.compatibility.dynmap.tooltip": "If enabled, Waystones will add markers for waystones and sharestones to Dynmap.",
+  "waystones.configuration.compatibility.fixVanillaTeleportBug": "Fix Vanilla Teleport Bug",
+  "waystones.configuration.compatibility.fixVanillaTeleportBug.tooltip": "Set to true to apply Waystones' entity teleport packet fix to all entity teleports, including vanilla and other mods.",
   "waystones.configuration.blueMap": "BlueMap",
   "waystones.configuration.blueMap.enabled": "Enable BlueMap Support",
   "waystones.configuration.blueMap.enabled.tooltip": "Controls whether Waystones' BlueMap integration should be loaded",

--- a/common/src/main/resources/waystones.mixins.json
+++ b/common/src/main/resources/waystones.mixins.json
@@ -5,12 +5,15 @@
   "refmap": "${mod_id}.refmap.json",
   "compatibilityLevel": "JAVA_17",
   "mixins": [
+    "EntityMixin",
     "JigsawPlacementPlacerMixin",
+    "ServerEntityMixin",
     "ServerScoreboardMixin",
     "SinglePoolElementMixin",
     "StructureTemplatePoolAccessor"
   ],
   "client": [
+    "ClientLevelAccessor",
     "ItemPropertiesAccessor"
   ],
   "injectors": {


### PR DESCRIPTION
Fix is active for Waystone teleports, and a config option (default: false) to apply it to all teleports including `/tp`.

Only thing I can still reproduce is getting unmounted when teleporting interdimensionally, but I can't be bothered to spend any more time on this. The fact that this is literally already fixed by Vanilla one version up in 1.21.2 has just further cemented my conviction that IT'S TIME TO MOVE ON from this 2 year old version.