### PR TITLE
Fix distance comparator overflow and `GenerateWaystoneNameEvent` dispatch

### DIFF
--- a/common/src/main/java/net/blay09/mods/waystones/core/PlayerWaystoneManager.java
+++ b/common/src/main/java/net/blay09/mods/waystones/core/PlayerWaystoneManager.java
@@ -103,7 +103,7 @@ public class PlayerWaystoneManager {
                 .min((first, second) -> {
                     double firstDist = player.distanceToSqr(Vec3.atCenterOf(first.getPos()));
                     double secondDist = player.distanceToSqr(Vec3.atCenterOf(second.getPos()));
-                    return (int) Math.round(firstDist) - (int) Math.round(secondDist);
+                    return Double.compare(firstDist, secondDist);
                 });
     }
 

--- a/common/src/main/java/net/blay09/mods/waystones/worldgen/namegen/NameGeneratorManager.java
+++ b/common/src/main/java/net/blay09/mods/waystones/worldgen/namegen/NameGeneratorManager.java
@@ -66,7 +66,7 @@ public class NameGeneratorManager extends SavedData {
         var name = resolveDuplicate(originalName);
 
         final var event = new GenerateWaystoneNameEvent(waystone, name);
-        GenerateWaystoneNameEvent.EVENT.invoker().accept(new GenerateWaystoneNameEvent(waystone, name));
+        GenerateWaystoneNameEvent.EVENT.invoker().accept(event);
         name = event.getName();
 
         usedNames.add(name.getString());


### PR DESCRIPTION
* **Fix integer overflow in nearest waystone calculation (`PlayerWaystoneManager`)**: Replaced manual `int` distance subtraction with `Double.compare()`. When waystones are far apart (squared distance > `Integer.MAX_VALUE`), casting the difference to an `int` overflows, violating `Comparator` contracts and causing crashes.
* **Fix event dispatch in `NameGeneratorManager`**: `getName()` previously allocated an `event` object, passed a *second* new `GenerateWaystoneNameEvent` instance to the event bus, and then read the name from the original un-fired `event`. Passing the existing `event` reference allows external listeners to properly modify generated names.